### PR TITLE
Feature/reconstruct chain id

### DIFF
--- a/contracts/PWNDeed.sol
+++ b/contracts/PWNDeed.sol
@@ -165,7 +165,7 @@ contract PWNDeed is ERC1155, Ownable {
         bytes32 eip712DomainSeparator = keccak256(abi.encode(
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
             keccak256(bytes("PWN")),
-            keccak256(bytes("2")),
+            keccak256(bytes("1")),
             block.chainid,
             address(this)
         ));

--- a/contracts/PWNDeed.sol
+++ b/contracts/PWNDeed.sol
@@ -43,11 +43,6 @@ contract PWNDeed is ERC1155, Ownable {
     );
 
     /**
-     * EIP-712 domain separator
-     */
-    bytes32 immutable internal EIP712_DOMAIN_SEPARATOR;
-
-    /**
      * Construct defining a Deed
      * @param status 0 == none/dead || 1 == new/open || 2 == running/accepted offer || 3 == paid back || 4 == expired
      * @param borrower Address of the borrower - stays the same for entire lifespan of the token
@@ -126,13 +121,7 @@ contract PWNDeed is ERC1155, Ownable {
      * @param _uri Uri to be used for finding the token metadata (https://api.pwn.finance/deed/...)
      */
     constructor(string memory _uri) ERC1155(_uri) Ownable() {
-        EIP712_DOMAIN_SEPARATOR = keccak256(abi.encode(
-            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-            keccak256(bytes("PWN")),
-            keccak256(bytes("2")),
-            block.chainid,
-            address(this)
-        ));
+
     }
 
     /**
@@ -173,8 +162,16 @@ contract PWNDeed is ERC1155, Ownable {
         bytes memory _signature,
         address _sender
     ) external onlyPWN {
+        bytes32 eip712DomainSeparator = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(bytes("PWN")),
+            keccak256(bytes("2")),
+            block.chainid,
+            address(this)
+        ));
+
         bytes32 offerHash = keccak256(abi.encodePacked(
-            "\x19\x01", EIP712_DOMAIN_SEPARATOR, hash(_offer)
+            "\x19\x01", eip712DomainSeparator, hash(_offer)
         ));
 
         if (_offer.lender.code.length > 0) {

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -16,7 +16,7 @@ async function timestampFromNow(delta) {
 function getEIP712Domain(address) {
 	return {
 		name: "PWN",
-		version: "2",
+		version: "1",
 		chainId: 31337, // Default hardhat network chain id
 		verifyingContract: address
 	}


### PR DESCRIPTION
We have a "minor" bug in a PWNDeed contract.

If ETH forks into another chain, it would be possible to execute replay attack. Currently, `chainid` is set on deployment, which would not change, if fork occurs. Signed offers from forked chain could be used in main chain. 

This fix increases the gas cost of `createDeed` by ~300 gas. I believe it's acceptable trade-off.