### PR TITLE
Late loan repayment feature

### DIFF
--- a/src/PWNErrors.sol
+++ b/src/PWNErrors.sol
@@ -10,6 +10,7 @@ error LoanDefaulted(uint40);
 error InvalidLoanStatus(uint256);
 error NonExistingLoan();
 error CallerNotLOANTokenHolder();
+error LateRepaymentIsAlreadyEnabled();
 
 // Invalid asset
 error InvalidLoanAsset();

--- a/src/loan-factory/simple-loan/offer/PWNSimpleLoanListOffer.sol
+++ b/src/loan-factory/simple-loan/offer/PWNSimpleLoanListOffer.sol
@@ -27,7 +27,7 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
      * @dev EIP-712 simple offer struct type hash.
      */
     bytes32 constant internal OFFER_TYPEHASH = keccak256(
-        "Offer(uint8 collateralCategory,address collateralAddress,bytes32 collateralIdsWhitelistMerkleRoot,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bytes32 nonce)"
+        "Offer(uint8 collateralCategory,address collateralAddress,bytes32 collateralIdsWhitelistMerkleRoot,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bool lateRepaymentEnabled,bytes32 nonce)"
     );
 
     /**
@@ -44,6 +44,7 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
      * @param borrower Address of a borrower. Only this address can accept an offer. If the address is zero address, anybody with a collateral can accept the offer.
      * @param lender Address of a lender. This address has to sign an offer to be valid.
      * @param isPersistent If true, offer will not be revoked on acceptance. Persistent offer can be revoked manually.
+     * @param lateRepaymentEnabled If true, a borrower can repay a loan even after an expiration date, but not after lender claims expired loan.
      * @param nonce Additional value to enable identical offers in time. Without it, it would be impossible to make again offer, which was once revoked.
      *              Can be used to create a group of offers, where accepting one offer will make other offers in the group revoked.
      */
@@ -60,6 +61,7 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
         address borrower;
         address lender;
         bool isPersistent;
+        bool lateRepaymentEnabled;
         bytes32 nonce;
     }
 
@@ -165,6 +167,7 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
             lender: lender,
             borrower: borrower,
             expiration: uint40(block.timestamp) + offer.duration,
+            lateRepaymentEnabled: offer.lateRepaymentEnabled,
             collateral: collateral,
             asset: loanAsset,
             loanRepayAmount: offer.loanAmount + offer.loanYield
@@ -212,6 +215,7 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
                     offer.borrower,
                     offer.lender,
                     offer.isPersistent,
+                    offer.lateRepaymentEnabled,
                     offer.nonce
                 )
             ))

--- a/src/loan-factory/simple-loan/offer/PWNSimpleLoanSimpleOffer.sol
+++ b/src/loan-factory/simple-loan/offer/PWNSimpleLoanSimpleOffer.sol
@@ -24,7 +24,7 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
      * @dev EIP-712 simple offer struct type hash.
      */
     bytes32 constant internal OFFER_TYPEHASH = keccak256(
-        "Offer(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bytes32 nonce)"
+        "Offer(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bool lateRepaymentEnabled,bytes32 nonce)"
     );
 
     /**
@@ -41,6 +41,7 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
      * @param borrower Address of a borrower. Only this address can accept an offer. If the address is zero address, anybody with a collateral can accept the offer.
      * @param lender Address of a lender. This address has to sign an offer to be valid.
      * @param isPersistent If true, offer will not be revoked on acceptance. Persistent offer can be revoked manually.
+     * @param lateRepaymentEnabled If true, a borrower can repay a loan even after an expiration date, but not after lender claims expired loan.
      * @param nonce Additional value to enable identical offers in time. Without it, it would be impossible to make again offer, which was once revoked.
      *              Can be used to create a group of offers, where accepting one offer will make other offers in the group revoked.
      */
@@ -57,6 +58,7 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
         address borrower;
         address lender;
         bool isPersistent;
+        bool lateRepaymentEnabled;
         bytes32 nonce;
     }
 
@@ -137,6 +139,7 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
             lender: lender,
             borrower: borrower,
             expiration: uint40(block.timestamp) + offer.duration,
+            lateRepaymentEnabled: offer.lateRepaymentEnabled,
             collateral: collateral,
             asset: loanAsset,
             loanRepayAmount: offer.loanAmount + offer.loanYield
@@ -184,6 +187,7 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
                     offer.borrower,
                     offer.lender,
                     offer.isPersistent,
+                    offer.lateRepaymentEnabled,
                     offer.nonce
                 )
             ))

--- a/src/loan-factory/simple-loan/request/PWNSimpleLoanSimpleRequest.sol
+++ b/src/loan-factory/simple-loan/request/PWNSimpleLoanSimpleRequest.sol
@@ -24,7 +24,7 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
      * @dev EIP-712 simple request struct type hash.
      */
     bytes32 constant internal REQUEST_TYPEHASH = keccak256(
-        "Request(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bytes32 nonce)"
+        "Request(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool lateRepaymentEnabled,bytes32 nonce)"
     );
 
     /**
@@ -40,6 +40,7 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
      * @param expiration Request expiration timestamp in seconds.
      * @param borrower Address of a borrower. This address has to sign a request to be valid.
      * @param lender Address of a lender. Only this address can accept a request. If the address is zero address, anybody with a loan asset can accept the request.
+     * @param lateRepaymentEnabled If true, a borrower can repay a loan even after an expiration date, but not after lender claims expired loan.
      * @param nonce Additional value to enable identical requests in time. Without it, it would be impossible to make again request, which was once revoked.
      *              Can be used to create a group of requests, where accepting one request will make other requests in the group revoked.
      */
@@ -55,6 +56,7 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
         uint40 expiration;
         address borrower;
         address lender;
+        bool lateRepaymentEnabled;
         bytes32 nonce;
     }
 
@@ -135,6 +137,7 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
             lender: lender,
             borrower: borrower,
             expiration: uint40(block.timestamp) + request.duration,
+            lateRepaymentEnabled: request.lateRepaymentEnabled,
             collateral: collateral,
             asset: loanAsset,
             loanRepayAmount: request.loanAmount + request.loanYield
@@ -179,6 +182,7 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
                     request.expiration,
                     request.borrower,
                     request.lender,
+                    request.lateRepaymentEnabled,
                     request.nonce
                 )
             ))

--- a/test/helper/BaseIntegrationTest.t.sol
+++ b/test/helper/BaseIntegrationTest.t.sol
@@ -94,6 +94,7 @@ abstract contract BaseIntegrationTest is Test {
             borrower: borrower,
             lender: lender,
             isPersistent: false,
+            lateRepaymentEnabled: false,
             nonce: nonce
         });
 
@@ -110,6 +111,7 @@ abstract contract BaseIntegrationTest is Test {
             expiration: 0,
             borrower: borrower,
             lender: lender,
+            lateRepaymentEnabled: false,
             nonce: nonce
         });
     }

--- a/test/integration/PWNSimpleLoanSimpleOfferIntegration.t.sol
+++ b/test/integration/PWNSimpleLoanSimpleOfferIntegration.t.sol
@@ -93,6 +93,7 @@ contract PWNSimpleLoanSimpleOfferIntegrationTest is BaseIntegrationTest {
             borrower: borrower,
             lender: lender,
             isPersistent: false,
+            lateRepaymentEnabled: false,
             nonce: nonce
         });
         bytes memory signature1 = _sign(lenderPK, simpleOffer.getOfferHash(offer));

--- a/test/integration/PWNSimpleLoanSimpleRequestIntegration.t.sol
+++ b/test/integration/PWNSimpleLoanSimpleRequestIntegration.t.sol
@@ -157,6 +157,7 @@ contract PWNSimpleLoanSimpleRequestIntegrationTest is BaseIntegrationTest {
             expiration: 0,
             borrower: borrower,
             lender: lender,
+            lateRepaymentEnabled: false,
             nonce: nonce
         });
         bytes memory signature1 = _sign(borrowerPK, simpleRequest.getRequestHash(request));

--- a/test/unit/PWNSimpleLoanListOffer.t.sol
+++ b/test/unit/PWNSimpleLoanListOffer.t.sol
@@ -47,6 +47,7 @@ abstract contract PWNSimpleLoanListOfferTest is Test {
             borrower: address(0),
             lender: lender,
             isPersistent: false,
+            lateRepaymentEnabled: false,
             nonce: keccak256("nonce_1")
         });
 
@@ -74,7 +75,7 @@ abstract contract PWNSimpleLoanListOfferTest is Test {
                 address(offerContract)
             )),
             keccak256(abi.encodePacked(
-                keccak256("Offer(uint8 collateralCategory,address collateralAddress,bytes32 collateralIdsWhitelistMerkleRoot,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bytes32 nonce)"),
+                keccak256("Offer(uint8 collateralCategory,address collateralAddress,bytes32 collateralIdsWhitelistMerkleRoot,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bool lateRepaymentEnabled,bytes32 nonce)"),
                 abi.encode(
                     _offer.collateralCategory,
                     _offer.collateralAddress,
@@ -90,6 +91,7 @@ abstract contract PWNSimpleLoanListOfferTest is Test {
                     _offer.borrower,
                     _offer.lender,
                     _offer.isPersistent,
+                    _offer.lateRepaymentEnabled,
                     _offer.nonce
                 )
             ))
@@ -354,10 +356,10 @@ contract PWNSimpleLoanListOffer_GetLOANTerms_Test is PWNSimpleLoanListOfferTest 
         vm.prank(activeLoanContract);
         PWNSimpleLoan.LOANTerms memory loanTerms = offerContract.getLOANTerms(borrower, abi.encode(offer, offerValues), signature);
 
-        // LOAN
         assertTrue(loanTerms.lender == offer.lender);
         assertTrue(loanTerms.borrower == borrower);
         assertTrue(loanTerms.expiration == currentTimestamp + offer.duration);
+        assertTrue(loanTerms.lateRepaymentEnabled == offer.lateRepaymentEnabled);
         assertTrue(loanTerms.collateral.category == offer.collateralCategory);
         assertTrue(loanTerms.collateral.assetAddress == offer.collateralAddress);
         assertTrue(loanTerms.collateral.id == offerValues.collateralId);

--- a/test/unit/PWNSimpleLoanSimpleOffer.t.sol
+++ b/test/unit/PWNSimpleLoanSimpleOffer.t.sol
@@ -46,6 +46,7 @@ abstract contract PWNSimpleLoanSimpleOfferTest is Test {
             borrower: address(0),
             lender: lender,
             isPersistent: false,
+            lateRepaymentEnabled: false,
             nonce: keccak256("nonce_1")
         });
 
@@ -68,7 +69,7 @@ abstract contract PWNSimpleLoanSimpleOfferTest is Test {
                 address(offerContract)
             )),
             keccak256(abi.encodePacked(
-                keccak256("Offer(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bytes32 nonce)"),
+                keccak256("Offer(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bool lateRepaymentEnabled,bytes32 nonce)"),
                 abi.encode(
                     _offer.collateralCategory,
                     _offer.collateralAddress,
@@ -84,6 +85,7 @@ abstract contract PWNSimpleLoanSimpleOfferTest is Test {
                     _offer.borrower,
                     _offer.lender,
                     _offer.isPersistent,
+                    _offer.lateRepaymentEnabled,
                     _offer.nonce
                 )
             ))
@@ -310,10 +312,10 @@ contract PWNSimpleLoanSimpleOffer_GetLOANTerms_Test is PWNSimpleLoanSimpleOfferT
         vm.prank(activeLoanContract);
         PWNSimpleLoan.LOANTerms memory loanTerms = offerContract.getLOANTerms(borrower, abi.encode(offer), signature);
 
-        // LOAN
         assertTrue(loanTerms.lender == offer.lender);
         assertTrue(loanTerms.borrower == borrower);
         assertTrue(loanTerms.expiration == currentTimestamp + offer.duration);
+        assertTrue(loanTerms.lateRepaymentEnabled == offer.lateRepaymentEnabled);
         assertTrue(loanTerms.collateral.category == offer.collateralCategory);
         assertTrue(loanTerms.collateral.assetAddress == offer.collateralAddress);
         assertTrue(loanTerms.collateral.id == offer.collateralId);

--- a/test/unit/PWNSimpleLoanSimpleRequest.t.sol
+++ b/test/unit/PWNSimpleLoanSimpleRequest.t.sol
@@ -45,6 +45,7 @@ abstract contract PWNSimpleLoanSimpleRequestTest is Test {
             expiration: 0,
             borrower: borrower,
             lender: address(0),
+            lateRepaymentEnabled: false,
             nonce: keccak256("nonce_1")
         });
 
@@ -67,7 +68,7 @@ abstract contract PWNSimpleLoanSimpleRequestTest is Test {
                 address(requestContract)
             )),
             keccak256(abi.encodePacked(
-                keccak256("Request(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bytes32 nonce)"),
+                keccak256("Request(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool lateRepaymentEnabled,bytes32 nonce)"),
                 abi.encode(
                     _request.collateralCategory,
                     _request.collateralAddress,
@@ -82,6 +83,7 @@ abstract contract PWNSimpleLoanSimpleRequestTest is Test {
                     _request.expiration,
                     _request.borrower,
                     _request.lender,
+                    _request.lateRepaymentEnabled,
                     _request.nonce
                 )
             ))
@@ -293,10 +295,10 @@ contract PWNSimpleLoanSimpleRequest_GetLOANTerms_Test is PWNSimpleLoanSimpleRequ
         vm.prank(activeLoanContract);
         PWNSimpleLoan.LOANTerms memory loanTerms = requestContract.getLOANTerms(lender, abi.encode(request), signature);
 
-        // LOAN
         assertTrue(loanTerms.lender == lender);
         assertTrue(loanTerms.borrower == request.borrower);
         assertTrue(loanTerms.expiration == currentTimestamp + request.duration);
+        assertTrue(loanTerms.lateRepaymentEnabled == request.lateRepaymentEnabled);
         assertTrue(loanTerms.collateral.category == request.collateralCategory);
         assertTrue(loanTerms.collateral.assetAddress == request.collateralAddress);
         assertTrue(loanTerms.collateral.id == request.collateralId);


### PR DESCRIPTION
Enable lender to specify, if borrower can repay loan after expiration. 
Late repayment, once enabled, cannot be disabled. 
Even when late repayment is enabled, lender can claim expired loans.