### PR TITLE
NM-0074

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,10 @@ on: push
 
 jobs:
   build:
-    name: Unit tests
+    name: Unit & Integration tests
+
+    env:
+      ETHEREUM_URL: ${{ secrets.ETHEREUM_URL }}
 
     runs-on: ubuntu-latest
 
@@ -20,4 +23,7 @@ jobs:
         run: forge install
 
       - name: Run unit tests
-        run: forge test
+        run: forge test --match-path "test/unit/*" --force
+
+      - name: Run integration tests
+        run: forge test --match-path "test/integration/*"

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,12 +8,12 @@ remappings = [
     "openzeppelin-contracts/contracts/=lib/openzeppelin-contracts/contracts/"
 ]
 no_match_path = "test/deployed/*"
+fs_permissions = [{ access = "read", path = "./deployments.json"}]
 
 
 [profile.deployed]
 match_path = "test/deployed/*"
 no_match_path = ""
-fs_permissions = [{ access = "read", path = "./deployments.json"}]
 
 
 [rpc_endpoints]

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,8 +4,7 @@ remappings = [
     "@pwn/=src/",
     "@pwn-test/=test/",
 
-    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
-    "openzeppelin-contracts/contracts/=lib/openzeppelin-contracts/contracts/"
+    "@openzeppelin/=lib/openzeppelin-contracts/contracts/"
 ]
 no_match_path = "test/deployed/*"
 fs_permissions = [{ access = "read", path = "./deployments.json"}]

--- a/src/PWNErrors.sol
+++ b/src/PWNErrors.sol
@@ -48,3 +48,4 @@ error InvalidInputData();
 
 // Config
 error InvalidFeeValue();
+error InvalidFeeCollector();

--- a/src/PWNErrors.sol
+++ b/src/PWNErrors.sol
@@ -10,7 +10,7 @@ error LoanDefaulted(uint40);
 error InvalidLoanStatus(uint256);
 error NonExistingLoan();
 error CallerNotLOANTokenHolder();
-error LateRepaymentIsAlreadyEnabled();
+error InvalidExtendedExpirationDate();
 
 // Invalid asset
 error InvalidLoanAsset();

--- a/src/PWNErrors.sol
+++ b/src/PWNErrors.sol
@@ -45,3 +45,6 @@ error InvalidDuration();
 
 // Input data
 error InvalidInputData();
+
+// Config
+error InvalidFeeValue();

--- a/src/PWNErrors.sol
+++ b/src/PWNErrors.sol
@@ -21,6 +21,7 @@ error InvalidLoanContractCaller();
 
 // Vault
 error UnsupportedTransferFunction();
+error IncompleteTransfer();
 
 // Nonce
 error NonceAlreadyRevoked();

--- a/src/PWNErrors.sol
+++ b/src/PWNErrors.sol
@@ -31,13 +31,16 @@ error InvalidSignatureLength(uint256);
 error InvalidSignature();
 
 // Offer
-error CallerIsNotStatedLender(address);
 error CallerIsNotStatedBorrower(address);
 error OfferExpired();
 error CollateralIdIsNotWhitelisted();
 
 // Request
+error CallerIsNotStatedLender(address);
 error RequestExpired();
+
+// Request & Offer
+error InvalidDuration();
 
 // Input data
 error InvalidInputData();

--- a/src/config/PWNConfig.sol
+++ b/src/config/PWNConfig.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity 0.8.16;
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/contracts/access/Ownable2Step.sol";
 import "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 
 
@@ -10,7 +10,7 @@ import "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
  * @notice Contract holding configurable values of PWN protocol.
  * @dev Is intendet to be used as a proxy via `TransparentUpgradeableProxy`.
  */
-contract PWNConfig is Ownable, Initializable {
+contract PWNConfig is Ownable2Step, Initializable {
 
     string internal constant VERSION = "1.0";
 
@@ -60,7 +60,7 @@ contract PWNConfig is Ownable, Initializable {
     |*  # CONSTRUCTOR                                           *|
     |*----------------------------------------------------------*/
 
-    constructor() Ownable() {
+    constructor() Ownable2Step() {
 
     }
 

--- a/src/config/PWNConfig.sol
+++ b/src/config/PWNConfig.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.16;
 import "openzeppelin-contracts/contracts/access/Ownable2Step.sol";
 import "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 
+import "@pwn/PWNErrors.sol";
+
 
 /**
  * @title PWN Config
@@ -17,6 +19,8 @@ contract PWNConfig is Ownable2Step, Initializable {
     /*----------------------------------------------------------*|
     |*  # VARIABLES & CONSTANTS DEFINITIONS                     *|
     |*----------------------------------------------------------*/
+
+    uint16 public constant MAX_FEE = 1000; // 10%
 
     /**
      * @notice Protocol fee value in basis points.
@@ -94,6 +98,9 @@ contract PWNConfig is Ownable2Step, Initializable {
     }
 
     function _setFee(uint16 _fee) private {
+        if (_fee > MAX_FEE)
+            revert InvalidFeeValue();
+
         uint16 oldFee = fee;
         fee = _fee;
         emit FeeUpdated(oldFee, _fee);

--- a/src/config/PWNConfig.sol
+++ b/src/config/PWNConfig.sol
@@ -116,6 +116,9 @@ contract PWNConfig is Ownable2Step, Initializable {
     }
 
     function _setFeeCollector(address _feeCollector) private {
+        if (_feeCollector == address(0))
+            revert InvalidFeeCollector();
+
         address oldFeeCollector = feeCollector;
         feeCollector = _feeCollector;
         emit FeeCollectorUpdated(oldFeeCollector, _feeCollector);

--- a/src/hub/PWNHub.sol
+++ b/src/hub/PWNHub.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity 0.8.16;
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/contracts/access/Ownable2Step.sol";
 
 import "@pwn/PWNErrors.sol";
 
@@ -10,7 +10,7 @@ import "@pwn/PWNErrors.sol";
  * @title PWN Hub
  * @notice Connects PWN contracts together into protocol via tags.
  */
-contract PWNHub is Ownable {
+contract PWNHub is Ownable2Step {
 
     /*----------------------------------------------------------*|
     |*  # VARIABLES & CONSTANTS DEFINITIONS                     *|
@@ -36,7 +36,7 @@ contract PWNHub is Ownable {
     |*  # CONSTRUCTOR                                           *|
     |*----------------------------------------------------------*/
 
-    constructor() Ownable() {
+    constructor() Ownable2Step() {
 
     }
 

--- a/src/loan/lib/PWNFeeCalculator.sol
+++ b/src/loan/lib/PWNFeeCalculator.sol
@@ -18,11 +18,15 @@ library PWNFeeCalculator {
      * @return newLoanAmount New amount of a loan credit asset, after deducting protocol fee.
      */
     function calculateFeeAmount(uint16 fee, uint256 loanAmount) internal pure returns (uint256 feeAmount, uint256 newLoanAmount) {
-        if (loanAmount < 1e4)
-            feeAmount = loanAmount * uint256(fee) / 1e4;
-        else
-            feeAmount = loanAmount / 1e4 * uint256(fee);
+        if (fee == 0)
+            return (0, loanAmount);
 
+        unchecked {
+            if ((loanAmount * fee) / fee == loanAmount)
+                feeAmount = loanAmount * uint256(fee) / 1e4;
+            else
+                feeAmount = loanAmount / 1e4 * uint256(fee);
+        }
         newLoanAmount = loanAmount - feeAmount;
     }
 

--- a/src/loan/terms/PWNLOANTerms.sol
+++ b/src/loan/terms/PWNLOANTerms.sol
@@ -12,7 +12,6 @@ library PWNLOANTerms {
      * @param lender Address of a lender.
      * @param borrower Address of a borrower.
      * @param expiration Unix timestamp (in seconds) setting up a default date.
-     * @param lateRepaymentEnabled If true, a borrower can repay a loan even after an expiration date, but not after lender claims expired loan.
      * @param collateral Asset used as a loan collateral. For a definition see { MultiToken dependency lib }.
      * @param asset Asset used as a loan credit. For a definition see { MultiToken dependency lib }.
      * @param loanRepayAmount Amount of a loan asset to be paid back.
@@ -21,7 +20,6 @@ library PWNLOANTerms {
         address lender;
         address borrower;
         uint40 expiration;
-        bool lateRepaymentEnabled;
         MultiToken.Asset collateral;
         MultiToken.Asset asset;
         uint256 loanRepayAmount;

--- a/src/loan/terms/simple/factory/PWNSimpleLoanTermsFactory.sol
+++ b/src/loan/terms/simple/factory/PWNSimpleLoanTermsFactory.sol
@@ -8,7 +8,9 @@ import "@pwn/loan/terms/PWNLOANTerms.sol";
  * @title PWN Simple Loan Terms Factory Interface
  * @notice Interface of a loan factory contract that builds a simple loan terms.
  */
-interface IPWNSimpleLoanTermsFactory {
+abstract contract PWNSimpleLoanTermsFactory {
+
+    uint32 public constant MIN_LOAN_DURATION = 600; // 10 min
 
     /**
      * @notice Build a simple loan terms from given data.
@@ -22,6 +24,6 @@ interface IPWNSimpleLoanTermsFactory {
         address caller,
         bytes calldata factoryData,
         bytes calldata signature
-    ) external returns (PWNLOANTerms.Simple memory loanTerms);
+    ) external virtual returns (PWNLOANTerms.Simple memory loanTerms);
 
 }

--- a/src/loan/terms/simple/factory/offer/PWNSimpleLoanListOffer.sol
+++ b/src/loan/terms/simple/factory/offer/PWNSimpleLoanListOffer.sol
@@ -145,6 +145,9 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
             if (borrower != offer.borrower)
                 revert CallerIsNotStatedBorrower(offer.borrower);
 
+        if (offer.duration == 0)
+            revert InvalidDuration();
+
         // Collateral id list
         if (offer.collateralIdsWhitelistMerkleRoot != bytes32(0)) {
             // Verify whitelisted collateral id

--- a/src/loan/terms/simple/factory/offer/PWNSimpleLoanListOffer.sol
+++ b/src/loan/terms/simple/factory/offer/PWNSimpleLoanListOffer.sol
@@ -145,7 +145,7 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
             if (borrower != offer.borrower)
                 revert CallerIsNotStatedBorrower(offer.borrower);
 
-        if (offer.duration == 0)
+        if (offer.duration < MIN_LOAN_DURATION)
             revert InvalidDuration();
 
         // Collateral id list

--- a/src/loan/terms/simple/factory/offer/PWNSimpleLoanListOffer.sol
+++ b/src/loan/terms/simple/factory/offer/PWNSimpleLoanListOffer.sol
@@ -28,7 +28,7 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
      * @dev EIP-712 simple offer struct type hash.
      */
     bytes32 constant internal OFFER_TYPEHASH = keccak256(
-        "Offer(uint8 collateralCategory,address collateralAddress,bytes32 collateralIdsWhitelistMerkleRoot,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bool lateRepaymentEnabled,uint256 nonce)"
+        "Offer(uint8 collateralCategory,address collateralAddress,bytes32 collateralIdsWhitelistMerkleRoot,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,uint256 nonce)"
     );
 
     bytes32 immutable internal DOMAIN_SEPARATOR;
@@ -47,7 +47,6 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
      * @param borrower Address of a borrower. Only this address can accept an offer. If the address is zero address, anybody with a collateral can accept the offer.
      * @param lender Address of a lender. This address has to sign an offer to be valid.
      * @param isPersistent If true, offer will not be revoked on acceptance. Persistent offer can be revoked manually.
-     * @param lateRepaymentEnabled If true, a borrower can repay a loan even after an expiration date, but not after lender claims expired loan.
      * @param nonce Additional value to enable identical offers in time. Without it, it would be impossible to make again offer, which was once revoked.
      *              Can be used to create a group of offers, where accepting one offer will make other offers in the group revoked.
      */
@@ -64,7 +63,6 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
         address borrower;
         address lender;
         bool isPersistent;
-        bool lateRepaymentEnabled;
         uint256 nonce;
     }
 
@@ -179,7 +177,6 @@ contract PWNSimpleLoanListOffer is PWNSimpleLoanOffer {
             lender: lender,
             borrower: borrower,
             expiration: uint40(block.timestamp) + offer.duration,
-            lateRepaymentEnabled: offer.lateRepaymentEnabled,
             collateral: collateral,
             asset: loanAsset,
             loanRepayAmount: offer.loanAmount + offer.loanYield

--- a/src/loan/terms/simple/factory/offer/PWNSimpleLoanSimpleOffer.sol
+++ b/src/loan/terms/simple/factory/offer/PWNSimpleLoanSimpleOffer.sol
@@ -129,6 +129,9 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
             if (borrower != offer.borrower)
                 revert CallerIsNotStatedBorrower(offer.borrower);
 
+        if (offer.duration == 0)
+            revert InvalidDuration();
+
         // Prepare collateral and loan asset
         MultiToken.Asset memory collateral = MultiToken.Asset({
             category: offer.collateralCategory,

--- a/src/loan/terms/simple/factory/offer/PWNSimpleLoanSimpleOffer.sol
+++ b/src/loan/terms/simple/factory/offer/PWNSimpleLoanSimpleOffer.sol
@@ -25,7 +25,7 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
      * @dev EIP-712 simple offer struct type hash.
      */
     bytes32 constant internal OFFER_TYPEHASH = keccak256(
-        "Offer(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bool lateRepaymentEnabled,uint256 nonce)"
+        "Offer(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,uint256 nonce)"
     );
 
     bytes32 immutable internal DOMAIN_SEPARATOR;
@@ -44,7 +44,6 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
      * @param borrower Address of a borrower. Only this address can accept an offer. If the address is zero address, anybody with a collateral can accept the offer.
      * @param lender Address of a lender. This address has to sign an offer to be valid.
      * @param isPersistent If true, offer will not be revoked on acceptance. Persistent offer can be revoked manually.
-     * @param lateRepaymentEnabled If true, a borrower can repay a loan even after an expiration date, but not after lender claims expired loan.
      * @param nonce Additional value to enable identical offers in time. Without it, it would be impossible to make again offer, which was once revoked.
      *              Can be used to create a group of offers, where accepting one offer will make other offers in the group revoked.
      */
@@ -61,7 +60,6 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
         address borrower;
         address lender;
         bool isPersistent;
-        bool lateRepaymentEnabled;
         uint256 nonce;
     }
 
@@ -151,7 +149,6 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
             lender: lender,
             borrower: borrower,
             expiration: uint40(block.timestamp) + offer.duration,
-            lateRepaymentEnabled: offer.lateRepaymentEnabled,
             collateral: collateral,
             asset: loanAsset,
             loanRepayAmount: offer.loanAmount + offer.loanYield

--- a/src/loan/terms/simple/factory/offer/PWNSimpleLoanSimpleOffer.sol
+++ b/src/loan/terms/simple/factory/offer/PWNSimpleLoanSimpleOffer.sol
@@ -129,7 +129,7 @@ contract PWNSimpleLoanSimpleOffer is PWNSimpleLoanOffer {
             if (borrower != offer.borrower)
                 revert CallerIsNotStatedBorrower(offer.borrower);
 
-        if (offer.duration == 0)
+        if (offer.duration < MIN_LOAN_DURATION)
             revert InvalidDuration();
 
         // Prepare collateral and loan asset

--- a/src/loan/terms/simple/factory/offer/base/PWNSimpleLoanOffer.sol
+++ b/src/loan/terms/simple/factory/offer/base/PWNSimpleLoanOffer.sol
@@ -2,18 +2,18 @@
 pragma solidity 0.8.16;
 
 import "@pwn/hub/PWNHubAccessControl.sol";
-import "@pwn/loan/terms/simple/factory/IPWNSimpleLoanTermsFactory.sol";
+import "@pwn/loan/terms/simple/factory/PWNSimpleLoanTermsFactory.sol";
 import "@pwn/nonce/PWNRevokedNonce.sol";
 import "@pwn/PWNErrors.sol";
 
 
-abstract contract PWNSimpleLoanOffer is IPWNSimpleLoanTermsFactory, PWNHubAccessControl {
+abstract contract PWNSimpleLoanOffer is PWNSimpleLoanTermsFactory, PWNHubAccessControl {
 
     /*----------------------------------------------------------*|
     |*  # VARIABLES & CONSTANTS DEFINITIONS                     *|
     |*----------------------------------------------------------*/
 
-    PWNRevokedNonce immutable internal revokedOfferNonce;
+    PWNRevokedNonce internal immutable revokedOfferNonce;
 
     /**
      * @dev Mapping of offers made via on-chain transactions.

--- a/src/loan/terms/simple/factory/request/PWNSimpleLoanSimpleRequest.sol
+++ b/src/loan/terms/simple/factory/request/PWNSimpleLoanSimpleRequest.sol
@@ -25,7 +25,7 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
      * @dev EIP-712 simple request struct type hash.
      */
     bytes32 constant internal REQUEST_TYPEHASH = keccak256(
-        "Request(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool lateRepaymentEnabled,uint256 nonce)"
+        "Request(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,uint256 nonce)"
     );
 
     bytes32 immutable internal DOMAIN_SEPARATOR;
@@ -43,7 +43,6 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
      * @param expiration Request expiration timestamp in seconds.
      * @param borrower Address of a borrower. This address has to sign a request to be valid.
      * @param lender Address of a lender. Only this address can accept a request. If the address is zero address, anybody with a loan asset can accept the request.
-     * @param lateRepaymentEnabled If true, a borrower can repay a loan even after an expiration date, but not after lender claims expired loan.
      * @param nonce Additional value to enable identical requests in time. Without it, it would be impossible to make again request, which was once revoked.
      *              Can be used to create a group of requests, where accepting one request will make other requests in the group revoked.
      */
@@ -59,7 +58,6 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
         uint40 expiration;
         address borrower;
         address lender;
-        bool lateRepaymentEnabled;
         uint256 nonce;
     }
 
@@ -149,7 +147,6 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
             lender: lender,
             borrower: borrower,
             expiration: uint40(block.timestamp) + request.duration,
-            lateRepaymentEnabled: request.lateRepaymentEnabled,
             collateral: collateral,
             asset: loanAsset,
             loanRepayAmount: request.loanAmount + request.loanYield

--- a/src/loan/terms/simple/factory/request/PWNSimpleLoanSimpleRequest.sol
+++ b/src/loan/terms/simple/factory/request/PWNSimpleLoanSimpleRequest.sol
@@ -127,6 +127,9 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
             if (lender != request.lender)
                 revert CallerIsNotStatedLender(request.lender);
 
+        if (request.duration == 0)
+            revert InvalidDuration();
+
         // Prepare collateral and loan asset
         MultiToken.Asset memory collateral = MultiToken.Asset({
             category: request.collateralCategory,

--- a/src/loan/terms/simple/factory/request/PWNSimpleLoanSimpleRequest.sol
+++ b/src/loan/terms/simple/factory/request/PWNSimpleLoanSimpleRequest.sol
@@ -127,7 +127,7 @@ contract PWNSimpleLoanSimpleRequest is PWNSimpleLoanRequest {
             if (lender != request.lender)
                 revert CallerIsNotStatedLender(request.lender);
 
-        if (request.duration == 0)
+        if (request.duration < MIN_LOAN_DURATION)
             revert InvalidDuration();
 
         // Prepare collateral and loan asset

--- a/src/loan/terms/simple/factory/request/base/PWNSimpleLoanRequest.sol
+++ b/src/loan/terms/simple/factory/request/base/PWNSimpleLoanRequest.sol
@@ -2,18 +2,18 @@
 pragma solidity 0.8.16;
 
 import "@pwn/hub/PWNHubAccessControl.sol";
-import "@pwn/loan/terms/simple/factory/IPWNSimpleLoanTermsFactory.sol";
+import "@pwn/loan/terms/simple/factory/PWNSimpleLoanTermsFactory.sol";
 import "@pwn/nonce/PWNRevokedNonce.sol";
 import "@pwn/PWNErrors.sol";
 
 
-abstract contract PWNSimpleLoanRequest is IPWNSimpleLoanTermsFactory, PWNHubAccessControl {
+abstract contract PWNSimpleLoanRequest is PWNSimpleLoanTermsFactory, PWNHubAccessControl {
 
     /*----------------------------------------------------------*|
     |*  # VARIABLES & CONSTANTS DEFINITIONS                     *|
     |*----------------------------------------------------------*/
 
-    PWNRevokedNonce immutable internal revokedRequestNonce;
+    PWNRevokedNonce internal immutable revokedRequestNonce;
 
     /**
      * @dev Mapping of requests made via on-chain transactions.

--- a/src/loan/terms/simple/loan/PWNSimpleLoan.sol
+++ b/src/loan/terms/simple/loan/PWNSimpleLoan.sol
@@ -38,8 +38,8 @@ contract PWNSimpleLoan is PWNVault, IERC5646, IPWNLoanMetadataProvider {
      * @param status 0 == none/dead || 2 == running/accepted offer/accepted request || 3 == paid back || 4 == expired.
      * @param borrower Address of a borrower.
      * @param expiration Unix timestamp (in seconds) setting up a default date.
-     * @param lateRepaymentEnabled If true, a borrower can repay a loan even after an expiration date, but not after lender claims expired loan.
      * @param loanAssetAddress Address of an asset used as a loan credit.
+     * @param loanRepayAmount Amount of a loan asset to be paid back.
      * @param collateral Asset used as a loan collateral. For a definition see { MultiToken dependency lib }.
      */
     struct LOAN {

--- a/src/loan/terms/simple/loan/PWNSimpleLoan.sol
+++ b/src/loan/terms/simple/loan/PWNSimpleLoan.sol
@@ -157,12 +157,14 @@ contract PWNSimpleLoan is PWNVault, IERC5646, IPWNLoanMetadataProvider {
             // Compute fee size
             (uint256 feeAmount, uint256 newLoanAmount) = PWNFeeCalculator.calculateFeeAmount(fee, loanTerms.asset.amount);
 
-            // Transfer fee amount to fee collector
-            loanTerms.asset.amount = feeAmount;
-            _pushFrom(loanTerms.asset, loanTerms.lender, config.feeCollector());
+            if (feeAmount > 0) {
+                // Transfer fee amount to fee collector
+                loanTerms.asset.amount = feeAmount;
+                _pushFrom(loanTerms.asset, loanTerms.lender, config.feeCollector());
 
-            // Set new loan amount value
-            loanTerms.asset.amount = newLoanAmount;
+                // Set new loan amount value
+                loanTerms.asset.amount = newLoanAmount;
+            }
         }
 
         // Transfer loan asset to borrower

--- a/src/loan/terms/simple/loan/PWNSimpleLoan.sol
+++ b/src/loan/terms/simple/loan/PWNSimpleLoan.sol
@@ -126,6 +126,10 @@ contract PWNSimpleLoan is PWNVault, IERC5646, IPWNLoanMetadataProvider {
             signature: signature
         });
 
+        // Check loan asset validity
+        if (MultiToken.isValid(loanTerms.asset) == false)
+            revert InvalidLoanAsset();
+
         // Check collateral validity
         if (MultiToken.isValid(loanTerms.collateral) == false)
             revert InvalidCollateralAsset();

--- a/src/loan/terms/simple/loan/PWNSimpleLoan.sol
+++ b/src/loan/terms/simple/loan/PWNSimpleLoan.sol
@@ -8,7 +8,7 @@ import "@pwn/hub/PWNHub.sol";
 import "@pwn/hub/PWNHubTags.sol";
 import "@pwn/loan/lib/PWNFeeCalculator.sol";
 import "@pwn/loan/terms/PWNLOANTerms.sol";
-import "@pwn/loan/terms/simple/factory/IPWNSimpleLoanTermsFactory.sol";
+import "@pwn/loan/terms/simple/factory/PWNSimpleLoanTermsFactory.sol";
 import "@pwn/loan/token/IERC5646.sol";
 import "@pwn/loan/token/PWNLOAN.sol";
 import "@pwn/loan/PWNVault.sol";
@@ -120,7 +120,7 @@ contract PWNSimpleLoan is PWNVault, IERC5646, IPWNLoanMetadataProvider {
             revert CallerMissingHubTag(PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY);
 
         // Build PWNLOANTerms.Simple by loan factory
-        PWNLOANTerms.Simple memory loanTerms = IPWNSimpleLoanTermsFactory(loanTermsFactoryContract).createLOANTerms({
+        PWNLOANTerms.Simple memory loanTerms = PWNSimpleLoanTermsFactory(loanTermsFactoryContract).createLOANTerms({
             caller: msg.sender,
             factoryData: loanTermsFactoryData,
             signature: signature

--- a/src/loan/terms/simple/loan/PWNSimpleLoan.sol
+++ b/src/loan/terms/simple/loan/PWNSimpleLoan.sol
@@ -328,10 +328,16 @@ contract PWNSimpleLoan is PWNVault, IERC5646, IPWNLoanMetadataProvider {
     /**
      * @notice Return a LOAN data struct associated with a loan id.
      * @param loanId Id of a loan in question.
-     * @return LOAN data struct or empty struct if the LOAN doesn't exist.
+     * @return loan LOAN data struct or empty struct if the LOAN doesn't exist.
      */
-    function getLOAN(uint256 loanId) external view returns (LOAN memory) {
-        return LOANs[loanId];
+    function getLOAN(uint256 loanId) external view returns (LOAN memory loan) {
+        loan = LOANs[loanId];
+        loan.status = _getLOANStatus(loanId);
+    }
+
+    function _getLOANStatus(uint256 loanId) private view returns (uint8) {
+        LOAN storage loan = LOANs[loanId];
+        return (loan.status == 2 && loan.expiration <= block.timestamp) ? 4 : loan.status;
     }
 
 

--- a/src/loan/terms/simple/loan/PWNSimpleLoan.sol
+++ b/src/loan/terms/simple/loan/PWNSimpleLoan.sol
@@ -361,18 +361,18 @@ contract PWNSimpleLoan is PWNVault, IERC5646, IPWNLoanMetadataProvider {
      * @dev See {IERC5646-getStateFingerprint}.
      */
     function getStateFingerprint(uint256 tokenId) external view virtual override returns (bytes32) {
-        LOAN memory loan = LOANs[tokenId];
+        LOAN storage loan = LOANs[tokenId];
 
         if (loan.status == 0)
             return bytes32(0);
 
         // The only mutable state properties are:
-        // - status, expiration, and if loan is expired (based on block.timestamp)
+        // - status, expiration
+        // Status is updated for expired loans based on block.timestamp.
         // Others don't have to be part of the state fingerprint as it does not act as a token identification.
         return keccak256(abi.encode(
-            loan.status,
-            loan.expiration,
-            loan.status == 2 && loan.expiration <= block.timestamp // is expired
+            _getLOANStatus(tokenId),
+            loan.expiration
         ));
     }
 

--- a/test/deployed/DeployedProtocol.t.sol
+++ b/test/deployed/DeployedProtocol.t.sol
@@ -3,77 +3,35 @@ pragma solidity 0.8.16;
 
 import "forge-std/Test.sol";
 
-import "openzeppelin-contracts/contracts/utils/Strings.sol";
-
-import "@pwn/config/PWNConfig.sol";
-import "@pwn/deployer/PWNDeployer.sol";
-import "@pwn/hub/PWNHub.sol";
-import "@pwn/hub/PWNHubTags.sol";
-import "@pwn/loan/terms/simple/loan/PWNSimpleLoan.sol";
-import "@pwn/loan/terms/simple/factory/offer/PWNSimpleLoanListOffer.sol";
-import "@pwn/loan/terms/simple/factory/offer/PWNSimpleLoanSimpleOffer.sol";
-import "@pwn/loan/terms/simple/factory/request/PWNSimpleLoanSimpleRequest.sol";
-import "@pwn/loan/token/PWNLOAN.sol";
-import "@pwn/nonce/PWNRevokedNonce.sol";
+import "@pwn-test/helper/DeploymentTest.t.sol";
 
 
 /*
 
 Run tests with this command:
 
-FOUNDRY_PROFILE=deployed forge test --fork-url [mainnet, polygon, goerli, mumbai, local]
+FOUNDRY_PROFILE=deployed forge t -f [mainnet, polygon, goerli, mumbai, local]
 
 */
-abstract contract DeployedProtocolTest is Test {
-    using stdJson for string;
-    using Strings for uint256;
-
+abstract contract DeployedProtocolTest is DeploymentTest {
     bytes32 internal constant PROXY_ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
-
-    // Properties need to be in alphabetical order
-    struct Deployment {
-        address admin;
-        PWNConfig config;
-        address dao;
-        PWNDeployer deployer;
-        address feeCollector;
-        PWNHub hub;
-        PWNLOAN loanToken;
-        PWNRevokedNonce revokedOfferNonce;
-        PWNRevokedNonce revokedRequestNonce;
-        PWNSimpleLoan simpleLoan;
-        PWNSimpleLoanSimpleOffer simpleLoanSimpleOffer;
-        PWNSimpleLoanListOffer simpleLoanListOffer;
-        PWNSimpleLoanSimpleRequest simpleLoanSimpleRequest;
-    }
-
-    Deployment deployment;
-
-    constructor() {
-        string memory root = vm.projectRoot();
-        string memory path = string.concat(root, "/deployments.json");
-        string memory json = vm.readFile(path);
-        bytes memory rawDeployment = json.parseRaw(string.concat(".", block.chainid.toString()));
-        deployment = abi.decode(rawDeployment, (Deployment));
-    }
-
 }
 
 
 contract DeployedProtocol_Addresses_Test is DeployedProtocolTest {
 
     function test_checkAddresses_Deployer() external {
-        assertEq(deployment.deployer.owner(), deployment.admin);
+        assertEq(deployer.owner(), admin);
     }
 
     function test_checkAddresses_Config() external {
-        assertEq(vm.load(address(deployment.config), PROXY_ADMIN_SLOT), bytes32(uint256(uint160(deployment.admin))));
-        assertEq(deployment.config.owner(), deployment.dao);
-        assertEq(deployment.config.feeCollector(), deployment.feeCollector);
+        assertEq(vm.load(address(config), PROXY_ADMIN_SLOT), bytes32(uint256(uint160(admin))));
+        assertEq(config.owner(), dao);
+        assertEq(config.feeCollector(), feeCollector);
     }
 
     function test_checkAddresses_Hub() external {
-        assertEq(deployment.hub.owner(), deployment.admin);
+        assertEq(hub.owner(), admin);
     }
 
 }
@@ -82,22 +40,22 @@ contract DeployedProtocol_Addresses_Test is DeployedProtocolTest {
 contract DeployedProtocol_Tags_Test is DeployedProtocolTest {
 
     function test_checkTags_SimpleLoan() external {
-        assertTrue(deployment.hub.hasTag(address(deployment.simpleLoan), PWNHubTags.ACTIVE_LOAN));
+        assertTrue(hub.hasTag(address(simpleLoan), PWNHubTags.ACTIVE_LOAN));
     }
 
     function test_checkTags_SimpleOffer() external {
-        assertTrue(deployment.hub.hasTag(address(deployment.simpleLoanSimpleOffer), PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY));
-        assertTrue(deployment.hub.hasTag(address(deployment.simpleLoanSimpleOffer), PWNHubTags.LOAN_OFFER));
+        assertTrue(hub.hasTag(address(simpleLoanSimpleOffer), PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY));
+        assertTrue(hub.hasTag(address(simpleLoanSimpleOffer), PWNHubTags.LOAN_OFFER));
     }
 
     function test_checkTags_ListOffer() external {
-        assertTrue(deployment.hub.hasTag(address(deployment.simpleLoanListOffer), PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY));
-        assertTrue(deployment.hub.hasTag(address(deployment.simpleLoanListOffer), PWNHubTags.LOAN_OFFER));
+        assertTrue(hub.hasTag(address(simpleLoanListOffer), PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY));
+        assertTrue(hub.hasTag(address(simpleLoanListOffer), PWNHubTags.LOAN_OFFER));
     }
 
     function test_checkTags_SimpleRequest() external {
-        assertTrue(deployment.hub.hasTag(address(deployment.simpleLoanSimpleRequest), PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY));
-        assertTrue(deployment.hub.hasTag(address(deployment.simpleLoanSimpleRequest), PWNHubTags.LOAN_REQUEST));
+        assertTrue(hub.hasTag(address(simpleLoanSimpleRequest), PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY));
+        assertTrue(hub.hasTag(address(simpleLoanSimpleRequest), PWNHubTags.LOAN_REQUEST));
     }
 
 }

--- a/test/helper/BaseIntegrationTest.t.sol
+++ b/test/helper/BaseIntegrationTest.t.sol
@@ -99,8 +99,8 @@ abstract contract BaseIntegrationTest is Test {
         config = PWNConfig(address(proxy));
         config.reinitialize(address(this), 0, feeCollector);
 
+        vm.prank(admin);
         hub = new PWNHub();
-        hub.transferOwnership(admin);
 
         loanToken = new PWNLOAN(address(hub));
         simpleLoan = new PWNSimpleLoan(address(hub), address(loanToken), address(config));

--- a/test/helper/DeploymentTest.t.sol
+++ b/test/helper/DeploymentTest.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.16;
+
+import "forge-std/Test.sol";
+
+import "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "openzeppelin-contracts/contracts/utils/Strings.sol";
+
+import "@pwn/config/PWNConfig.sol";
+import "@pwn/deployer/PWNDeployer.sol";
+import "@pwn/hub/PWNHub.sol";
+import "@pwn/hub/PWNHubTags.sol";
+import "@pwn/loan/terms/simple/loan/PWNSimpleLoan.sol";
+import "@pwn/loan/terms/simple/factory/offer/PWNSimpleLoanListOffer.sol";
+import "@pwn/loan/terms/simple/factory/offer/PWNSimpleLoanSimpleOffer.sol";
+import "@pwn/loan/terms/simple/factory/request/PWNSimpleLoanSimpleRequest.sol";
+import "@pwn/loan/token/PWNLOAN.sol";
+import "@pwn/nonce/PWNRevokedNonce.sol";
+
+
+abstract contract DeploymentTest is Test {
+    using stdJson for string;
+    using Strings for uint256;
+
+    Deployment deployment;
+
+    // Properties need to be in alphabetical order
+    struct Deployment {
+        address admin;
+        PWNConfig config;
+        address dao;
+        PWNDeployer deployer;
+        address feeCollector;
+        PWNHub hub;
+        PWNLOAN loanToken;
+        PWNRevokedNonce revokedOfferNonce;
+        PWNRevokedNonce revokedRequestNonce;
+        PWNSimpleLoan simpleLoan;
+        PWNSimpleLoanSimpleOffer simpleLoanSimpleOffer;
+        PWNSimpleLoanListOffer simpleLoanListOffer;
+        PWNSimpleLoanSimpleRequest simpleLoanSimpleRequest;
+    }
+
+    address admin;
+    address dao;
+    address feeCollector;
+
+    PWNDeployer deployer;
+    PWNHub hub;
+    PWNConfig config;
+    PWNLOAN loanToken;
+    PWNSimpleLoan simpleLoan;
+    PWNRevokedNonce revokedOfferNonce;
+    PWNRevokedNonce revokedRequestNonce;
+    PWNSimpleLoanSimpleOffer simpleLoanSimpleOffer;
+    PWNSimpleLoanListOffer simpleLoanListOffer;
+    PWNSimpleLoanSimpleRequest simpleLoanSimpleRequest;
+
+    constructor() {
+        // skip for local devnet
+        if (block.chainid != 31337) {
+            string memory root = vm.projectRoot();
+            string memory path = string.concat(root, "/deployments.json");
+            string memory json = vm.readFile(path);
+            bytes memory rawDeployment = json.parseRaw(string.concat(".", block.chainid.toString()));
+            deployment = abi.decode(rawDeployment, (Deployment));
+        }
+    }
+
+
+    function setUp() public virtual {
+        if (block.chainid == 31337) { // local devnet
+            admin = makeAddr("admin");
+            dao = makeAddr("dao");
+            feeCollector = makeAddr("feeCollector");
+
+            _deployProtocol();
+        } else {
+            admin = deployment.admin;
+            dao = deployment.dao;
+            feeCollector = deployment.feeCollector;
+            deployer = deployment.deployer;
+            hub = deployment.hub;
+            config = deployment.config;
+            loanToken = deployment.loanToken;
+            simpleLoan = deployment.simpleLoan;
+            revokedOfferNonce = deployment.revokedOfferNonce;
+            revokedRequestNonce = deployment.revokedRequestNonce;
+            simpleLoanSimpleOffer = deployment.simpleLoanSimpleOffer;
+            simpleLoanListOffer = deployment.simpleLoanListOffer;
+            simpleLoanSimpleRequest = deployment.simpleLoanSimpleRequest;
+        }
+    }
+
+
+    function _deployProtocol() private {
+        // Deploy realm
+        PWNConfig configSingleton = new PWNConfig();
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(configSingleton),
+            admin,
+            abi.encodeWithSignature("initialize(address)", address(this))
+        );
+        config = PWNConfig(address(proxy));
+        config.reinitialize(address(this), 0, feeCollector);
+
+        vm.prank(admin);
+        hub = new PWNHub();
+
+        loanToken = new PWNLOAN(address(hub));
+        simpleLoan = new PWNSimpleLoan(address(hub), address(loanToken), address(config));
+
+        revokedOfferNonce = new PWNRevokedNonce(address(hub), PWNHubTags.LOAN_OFFER);
+        simpleLoanSimpleOffer = new PWNSimpleLoanSimpleOffer(address(hub), address(revokedOfferNonce));
+        simpleLoanListOffer = new PWNSimpleLoanListOffer(address(hub), address(revokedOfferNonce));
+
+        revokedRequestNonce = new PWNRevokedNonce(address(hub), PWNHubTags.LOAN_REQUEST);
+        simpleLoanSimpleRequest = new PWNSimpleLoanSimpleRequest(address(hub), address(revokedRequestNonce));
+
+        // Set hub tags
+        address[] memory addrs = new address[](7);
+        addrs[0] = address(simpleLoan);
+        addrs[1] = address(simpleLoanSimpleOffer);
+        addrs[2] = address(simpleLoanSimpleOffer);
+        addrs[3] = address(simpleLoanListOffer);
+        addrs[4] = address(simpleLoanListOffer);
+        addrs[5] = address(simpleLoanSimpleRequest);
+        addrs[6] = address(simpleLoanSimpleRequest);
+
+        bytes32[] memory tags = new bytes32[](7);
+        tags[0] = PWNHubTags.ACTIVE_LOAN;
+        tags[1] = PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY;
+        tags[2] = PWNHubTags.LOAN_OFFER;
+        tags[3] = PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY;
+        tags[4] = PWNHubTags.LOAN_OFFER;
+        tags[5] = PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY;
+        tags[6] = PWNHubTags.LOAN_REQUEST;
+
+        vm.prank(admin);
+        hub.setTags(addrs, tags, true);
+    }
+
+}

--- a/test/helper/DeploymentTest.t.sol
+++ b/test/helper/DeploymentTest.t.sol
@@ -57,8 +57,7 @@ abstract contract DeploymentTest is Test {
     PWNSimpleLoanSimpleRequest simpleLoanSimpleRequest;
 
     constructor() {
-        // skip for local devnet
-        if (block.chainid != 31337) {
+        if (block.chainid == 5 /*|| block.chainid == 1*/) {
             string memory root = vm.projectRoot();
             string memory path = string.concat(root, "/deployments.json");
             string memory json = vm.readFile(path);
@@ -69,13 +68,7 @@ abstract contract DeploymentTest is Test {
 
 
     function setUp() public virtual {
-        if (block.chainid == 31337) { // local devnet
-            admin = makeAddr("admin");
-            dao = makeAddr("dao");
-            feeCollector = makeAddr("feeCollector");
-
-            _deployProtocol();
-        } else {
+        if (block.chainid == 5 /*|| block.chainid == 1*/) {
             admin = deployment.admin;
             dao = deployment.dao;
             feeCollector = deployment.feeCollector;
@@ -89,12 +82,18 @@ abstract contract DeploymentTest is Test {
             simpleLoanSimpleOffer = deployment.simpleLoanSimpleOffer;
             simpleLoanListOffer = deployment.simpleLoanListOffer;
             simpleLoanSimpleRequest = deployment.simpleLoanSimpleRequest;
+        } else {
+            _deployProtocol();
         }
     }
 
 
-    function _deployProtocol() private {
-        // Deploy realm
+    function _deployProtocol() internal {
+        admin = makeAddr("admin");
+        dao = makeAddr("dao");
+        feeCollector = makeAddr("feeCollector");
+
+        // Deploy protocol
         PWNConfig configSingleton = new PWNConfig();
         TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
             address(configSingleton),

--- a/test/helper/token/T20.sol
+++ b/test/helper/token/T20.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 
 

--- a/test/integration/contracts/BaseIntegrationTest.t.sol
+++ b/test/integration/contracts/BaseIntegrationTest.t.sol
@@ -5,42 +5,19 @@ import "forge-std/Test.sol";
 
 import "MultiToken/MultiToken.sol";
 
-import "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-
-import "@pwn/config/PWNConfig.sol";
-import "@pwn/hub/PWNHub.sol";
-import "@pwn/hub/PWNHubTags.sol";
-import "@pwn/loan/terms/simple/loan/PWNSimpleLoan.sol";
-import "@pwn/loan/terms/simple/factory/offer/PWNSimpleLoanSimpleOffer.sol";
-import "@pwn/loan/terms/simple/factory/offer/PWNSimpleLoanListOffer.sol";
-import "@pwn/loan/terms/simple/factory/request/PWNSimpleLoanSimpleRequest.sol";
-import "@pwn/loan/token/PWNLOAN.sol";
-import "@pwn/nonce/PWNRevokedNonce.sol";
-
 import "@pwn-test/helper/token/T20.sol";
 import "@pwn-test/helper/token/T721.sol";
 import "@pwn-test/helper/token/T1155.sol";
+import "@pwn-test/helper/DeploymentTest.t.sol";
 
 
-abstract contract BaseIntegrationTest is Test {
+abstract contract BaseIntegrationTest is DeploymentTest {
 
     T20 t20;
     T721 t721;
     T1155 t1155;
     T20 loanAsset;
 
-    PWNHub hub;
-    PWNConfig config;
-    PWNLOAN loanToken;
-    PWNSimpleLoan simpleLoan;
-    PWNRevokedNonce revokedOfferNonce;
-    PWNRevokedNonce revokedRequestNonce;
-    PWNSimpleLoanSimpleOffer simpleOffer;
-    PWNSimpleLoanListOffer listOffer;
-    PWNSimpleLoanSimpleRequest simpleRequest;
-
-    address admin = address(0xad814);
-    address feeCollector = address(0xfeeC001ec704);
     uint256 lenderPK = uint256(777);
     address lender = vm.addr(lenderPK);
     uint256 borrowerPK = uint256(888);
@@ -48,20 +25,8 @@ abstract contract BaseIntegrationTest is Test {
     uint256 nonce = uint256(keccak256("nonce_1"));
     PWNSimpleLoanSimpleOffer.Offer defaultOffer;
 
-    function setUp() external {
-        if (block.chainid == 31337)
-            _deployRealm();
-        else if (block.chainid == 5) {
-            hub = PWNHub(0xd31b4cfee06B8a662F522CaBC2D925038Be0aAC5);
-            config = PWNConfig(0x2adA1d4F43021A5786393E7C62bE6A8efF766b1C);
-            loanToken = PWNLOAN(0xa0A4886398e509250d5734B31F7323019774B5e5);
-            simpleLoan = PWNSimpleLoan(0x05397F372130bE1Ab43dF72c896278Bff2Db8A9E);
-            revokedOfferNonce = PWNRevokedNonce(0xF5A49a2f6d9E03e152dDCDEaaC6d479AC8eB92A7);
-            revokedRequestNonce = PWNRevokedNonce(0x70aDA3E22E755593Db05B5342062eB849B8E8ccd);
-            simpleOffer = PWNSimpleLoanSimpleOffer(0xaff389b04AC4D42Ff0d497d2a3C305ab4A5d629D);
-            listOffer = PWNSimpleLoanListOffer(0xC0d64e5cc29a7FE91a82C40b71E46f69F0fFFBdd);
-            simpleRequest = PWNSimpleLoanSimpleRequest(0x6f3E641DA9201B6C60bb7964Ac4d55EE27af24C3);
-        }
+    function setUp() public override {
+        super.setUp();
 
         // Deploy tokens
         t20 = new T20();
@@ -88,52 +53,6 @@ abstract contract BaseIntegrationTest is Test {
         });
     }
 
-    function _deployRealm() private {
-        // Deploy realm
-        PWNConfig configSingleton = new PWNConfig();
-        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
-            address(configSingleton),
-            admin,
-            abi.encodeWithSignature("initialize(address)", address(this))
-        );
-        config = PWNConfig(address(proxy));
-        config.reinitialize(address(this), 0, feeCollector);
-
-        vm.prank(admin);
-        hub = new PWNHub();
-
-        loanToken = new PWNLOAN(address(hub));
-        simpleLoan = new PWNSimpleLoan(address(hub), address(loanToken), address(config));
-
-        revokedOfferNonce = new PWNRevokedNonce(address(hub), PWNHubTags.LOAN_OFFER);
-        simpleOffer = new PWNSimpleLoanSimpleOffer(address(hub), address(revokedOfferNonce));
-        listOffer = new PWNSimpleLoanListOffer(address(hub), address(revokedOfferNonce));
-
-        revokedRequestNonce = new PWNRevokedNonce(address(hub), PWNHubTags.LOAN_REQUEST);
-        simpleRequest = new PWNSimpleLoanSimpleRequest(address(hub), address(revokedRequestNonce));
-
-        // Set hub tags
-        address[] memory addrs = new address[](7);
-        addrs[0] = address(simpleLoan);
-        addrs[1] = address(simpleOffer);
-        addrs[2] = address(simpleOffer);
-        addrs[3] = address(listOffer);
-        addrs[4] = address(listOffer);
-        addrs[5] = address(simpleRequest);
-        addrs[6] = address(simpleRequest);
-
-        bytes32[] memory tags = new bytes32[](7);
-        tags[0] = PWNHubTags.ACTIVE_LOAN;
-        tags[1] = PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY;
-        tags[2] = PWNHubTags.LOAN_OFFER;
-        tags[3] = PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY;
-        tags[4] = PWNHubTags.LOAN_OFFER;
-        tags[5] = PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY;
-        tags[6] = PWNHubTags.LOAN_REQUEST;
-
-        vm.prank(admin);
-        hub.setTags(addrs, tags, true);
-    }
 
     function _sign(uint256 pk, bytes32 digest) internal pure returns (bytes memory) {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
@@ -202,7 +121,7 @@ abstract contract BaseIntegrationTest is Test {
 
     function _createLoan(PWNSimpleLoanSimpleOffer.Offer memory _offer, bytes memory revertData) private returns (uint256) {
         // Sign offer
-        bytes memory signature = _sign(lenderPK, simpleOffer.getOfferHash(_offer));
+        bytes memory signature = _sign(lenderPK, simpleLoanSimpleOffer.getOfferHash(_offer));
 
         // Mint initial state
         loanAsset.mint(lender, 100e18);
@@ -212,7 +131,7 @@ abstract contract BaseIntegrationTest is Test {
         loanAsset.approve(address(simpleLoan), 100e18);
 
         // Loan factory data (need for vm.prank to work properly when creating a loan)
-        bytes memory loanTermsFactoryData = simpleOffer.encodeLoanTermsFactoryData(_offer);
+        bytes memory loanTermsFactoryData = simpleLoanSimpleOffer.encodeLoanTermsFactoryData(_offer);
 
         // Create LOAN
         if (keccak256(revertData) != keccak256("")) {
@@ -220,7 +139,7 @@ abstract contract BaseIntegrationTest is Test {
         }
         vm.prank(borrower);
         return simpleLoan.createLOAN({
-            loanTermsFactoryContract: address(simpleOffer),
+            loanTermsFactoryContract: address(simpleLoanSimpleOffer),
             loanTermsFactoryData: loanTermsFactoryData,
             signature: signature,
             loanAssetPermit: "",

--- a/test/integration/contracts/BaseIntegrationTest.t.sol
+++ b/test/integration/contracts/BaseIntegrationTest.t.sol
@@ -48,7 +48,6 @@ abstract contract BaseIntegrationTest is DeploymentTest {
             borrower: borrower,
             lender: lender,
             isPersistent: false,
-            lateRepaymentEnabled: false,
             nonce: nonce
         });
     }

--- a/test/integration/contracts/PWNProtocolIntegrity.t.sol
+++ b/test/integration/contracts/PWNProtocolIntegrity.t.sol
@@ -6,7 +6,7 @@ import "forge-std/Test.sol";
 import "@pwn/hub/PWNHubTags.sol";
 import "@pwn/PWNErrors.sol";
 
-import "@pwn-test/helper/BaseIntegrationTest.t.sol";
+import "@pwn-test/integration/contracts/BaseIntegrationTest.t.sol";
 
 
 contract PWNProtocolIntegrityTest is BaseIntegrationTest {
@@ -82,13 +82,13 @@ contract PWNProtocolIntegrityTest is BaseIntegrationTest {
             abi.encodeWithSelector(CallerMissingHubTag.selector, PWNHubTags.ACTIVE_LOAN)
         );
         vm.prank(address(simpleLoan));
-        simpleOffer.createLOANTerms(borrower, "", ""); // Offer data are not important in this test
+        simpleLoanSimpleOffer.createLOANTerms(borrower, "", ""); // Offer data are not important in this test
     }
 
     function test_shouldFail_whenPassingInvalidTermsFactoryContract() external {
         // Remove SIMPLE_LOAN_TERMS_FACTORY tag
         vm.prank(admin);
-        hub.setTag(address(simpleOffer), PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY, false);
+        hub.setTag(address(simpleLoanSimpleOffer), PWNHubTags.SIMPLE_LOAN_TERMS_FACTORY, false);
 
         // Try to create LOAN
         _createERC1155LoanFailing(

--- a/test/integration/contracts/PWNSimpleLoanIntegration.t.sol
+++ b/test/integration/contracts/PWNSimpleLoanIntegration.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import "@pwn/PWNErrors.sol";
 
-import "@pwn-test/helper/BaseIntegrationTest.t.sol";
+import "@pwn-test/integration/contracts/BaseIntegrationTest.t.sol";
 
 
 contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
@@ -38,7 +38,7 @@ contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
         t1155.setApprovalForAll(address(simpleLoan), true);
 
         // Sign offer
-        bytes memory signature = _sign(lenderPK, simpleOffer.getOfferHash(offer));
+        bytes memory signature = _sign(lenderPK, simpleLoanSimpleOffer.getOfferHash(offer));
 
         // Mint initial state
         loanAsset.mint(lender, 100e18);
@@ -48,12 +48,12 @@ contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
         loanAsset.approve(address(simpleLoan), 100e18);
 
         // Loan factory data (need for vm.prank to work properly when creating a loan)
-        bytes memory loanTermsFactoryData = simpleOffer.encodeLoanTermsFactoryData(offer);
+        bytes memory loanTermsFactoryData = simpleLoanSimpleOffer.encodeLoanTermsFactoryData(offer);
 
         // Create LOAN
         vm.prank(borrower);
         uint256 loanId = simpleLoan.createLOAN({
-            loanTermsFactoryContract: address(simpleOffer),
+            loanTermsFactoryContract: address(simpleLoanSimpleOffer),
             loanTermsFactoryData: loanTermsFactoryData,
             signature: signature,
             loanAssetPermit: "",
@@ -111,7 +111,7 @@ contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
         t1155.setApprovalForAll(address(simpleLoan), true);
 
         // Sign offer
-        bytes memory signature = _sign(lenderPK, listOffer.getOfferHash(offer));
+        bytes memory signature = _sign(lenderPK, simpleLoanListOffer.getOfferHash(offer));
 
         // Mint initial state
         loanAsset.mint(lender, 100e18);
@@ -121,12 +121,12 @@ contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
         loanAsset.approve(address(simpleLoan), 100e18);
 
         // Loan factory data (need for vm.prank to work properly when creating a loan)
-        bytes memory loanTermsFactoryData = listOffer.encodeLoanTermsFactoryData(offer, offerValues);
+        bytes memory loanTermsFactoryData = simpleLoanListOffer.encodeLoanTermsFactoryData(offer, offerValues);
 
         // Create LOAN
         vm.prank(borrower);
         uint256 loanId = simpleLoan.createLOAN({
-            loanTermsFactoryContract: address(listOffer),
+            loanTermsFactoryContract: address(simpleLoanListOffer),
             loanTermsFactoryData: loanTermsFactoryData,
             signature: signature,
             loanAssetPermit: "",
@@ -173,7 +173,7 @@ contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
         t1155.setApprovalForAll(address(simpleLoan), true);
 
         // Sign request
-        bytes memory signature = _sign(borrowerPK, simpleRequest.getRequestHash(request));
+        bytes memory signature = _sign(borrowerPK, simpleLoanSimpleRequest.getRequestHash(request));
 
         // Mint initial state
         loanAsset.mint(lender, 100e18);
@@ -183,12 +183,12 @@ contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
         loanAsset.approve(address(simpleLoan), 100e18);
 
         // Loan factory data (need for vm.prank to work properly when creating a loan)
-        bytes memory loanTermsFactoryData = simpleRequest.encodeLoanTermsFactoryData(request);
+        bytes memory loanTermsFactoryData = simpleLoanSimpleRequest.encodeLoanTermsFactoryData(request);
 
         // Create LOAN
         vm.prank(lender);
         uint256 loanId = simpleLoan.createLOAN({
-            loanTermsFactoryContract: address(simpleRequest),
+            loanTermsFactoryContract: address(simpleLoanSimpleRequest),
             loanTermsFactoryData: loanTermsFactoryData,
             signature: signature,
             loanAssetPermit: "",

--- a/test/integration/contracts/PWNSimpleLoanIntegration.t.sol
+++ b/test/integration/contracts/PWNSimpleLoanIntegration.t.sol
@@ -26,7 +26,6 @@ contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
             borrower: borrower,
             lender: lender,
             isPersistent: false,
-            lateRepaymentEnabled: false,
             nonce: nonce
         });
 
@@ -93,7 +92,6 @@ contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
             borrower: borrower,
             lender: lender,
             isPersistent: false,
-            lateRepaymentEnabled: false,
             nonce: nonce
         });
 
@@ -161,7 +159,6 @@ contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
             expiration: 0,
             borrower: borrower,
             lender: lender,
-            lateRepaymentEnabled: false,
             nonce: nonce
         });
 
@@ -307,33 +304,6 @@ contract PWNSimpleLoanIntegrationTest is BaseIntegrationTest {
             loanId,
             abi.encodeWithSelector(LoanDefaulted.selector, uint40(expiration))
         );
-    }
-
-    function test_shouldRepayLoan_whenExpired_withLateRepaymentEnabled() external {
-        // Create LOAN
-        uint256 loanId = _createERC1155Loan();
-
-        // Default on a loan
-        uint256 expiration = block.timestamp + uint256(defaultOffer.duration);
-        vm.warp(expiration);
-
-        // Enable late repayment
-        vm.prank(lender);
-        simpleLoan.enableLOANLateRepayment(loanId);
-
-        // Repay loan
-        _repayLoan(loanId);
-
-        // Assert final state
-        assertEq(loanToken.ownerOf(loanId), lender);
-
-        assertEq(loanAsset.balanceOf(lender), 0);
-        assertEq(loanAsset.balanceOf(borrower), 0);
-        assertEq(loanAsset.balanceOf(address(simpleLoan)), 110e18);
-
-        assertEq(t1155.balanceOf(lender, 42), 0);
-        assertEq(t1155.balanceOf(borrower, 42), 10e18);
-        assertEq(t1155.balanceOf(address(simpleLoan), 42), 0);
     }
 
 

--- a/test/integration/contracts/PWNSimpleLoanSimpleOfferIntegration.t.sol
+++ b/test/integration/contracts/PWNSimpleLoanSimpleOfferIntegration.t.sol
@@ -31,7 +31,6 @@ contract PWNSimpleLoanSimpleOfferIntegrationTest is BaseIntegrationTest {
             borrower: borrower,
             lender: lender,
             isPersistent: false,
-            lateRepaymentEnabled: false,
             nonce: nonce
         });
         bytes memory signature1 = _sign(lenderPK, simpleLoanSimpleOffer.getOfferHash(offer));

--- a/test/integration/contracts/PWNSimpleLoanSimpleOfferIntegration.t.sol
+++ b/test/integration/contracts/PWNSimpleLoanSimpleOfferIntegration.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import "@pwn/PWNErrors.sol";
 
-import "@pwn-test/helper/BaseIntegrationTest.t.sol";
+import "@pwn-test/integration/contracts/BaseIntegrationTest.t.sol";
 
 
 contract PWNSimpleLoanSimpleOfferIntegrationTest is BaseIntegrationTest {
@@ -34,11 +34,11 @@ contract PWNSimpleLoanSimpleOfferIntegrationTest is BaseIntegrationTest {
             lateRepaymentEnabled: false,
             nonce: nonce
         });
-        bytes memory signature1 = _sign(lenderPK, simpleOffer.getOfferHash(offer));
+        bytes memory signature1 = _sign(lenderPK, simpleLoanSimpleOffer.getOfferHash(offer));
         bytes memory offerData1 = abi.encode(offer);
 
         offer.loanYield = 20e18;
-        bytes memory signature2 = _sign(lenderPK, simpleOffer.getOfferHash(offer));
+        bytes memory signature2 = _sign(lenderPK, simpleLoanSimpleOffer.getOfferHash(offer));
         bytes memory offerData2 = abi.encode(offer);
 
         // Approve loan asset
@@ -52,7 +52,7 @@ contract PWNSimpleLoanSimpleOfferIntegrationTest is BaseIntegrationTest {
         // Create LOAN with offer 2
         vm.prank(borrower);
         simpleLoan.createLOAN({
-            loanTermsFactoryContract: address(simpleOffer),
+            loanTermsFactoryContract: address(simpleLoanSimpleOffer),
             loanTermsFactoryData: offerData2,
             signature: signature2,
             loanAssetPermit: "",
@@ -63,7 +63,7 @@ contract PWNSimpleLoanSimpleOfferIntegrationTest is BaseIntegrationTest {
         vm.expectRevert(abi.encodeWithSelector(NonceAlreadyRevoked.selector));
         vm.prank(borrower);
         simpleLoan.createLOAN({
-            loanTermsFactoryContract: address(simpleOffer),
+            loanTermsFactoryContract: address(simpleLoanSimpleOffer),
             loanTermsFactoryData: offerData1,
             signature: signature1,
             loanAssetPermit: "",

--- a/test/integration/contracts/PWNSimpleLoanSimpleRequestIntegration.t.sol
+++ b/test/integration/contracts/PWNSimpleLoanSimpleRequestIntegration.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import "@pwn/PWNErrors.sol";
 
-import "@pwn-test/helper/BaseIntegrationTest.t.sol";
+import "@pwn-test/integration/contracts/BaseIntegrationTest.t.sol";
 
 
 contract PWNSimpleLoanSimpleRequestIntegrationTest is BaseIntegrationTest {
@@ -33,11 +33,11 @@ contract PWNSimpleLoanSimpleRequestIntegrationTest is BaseIntegrationTest {
             lateRepaymentEnabled: false,
             nonce: nonce
         });
-        bytes memory signature1 = _sign(borrowerPK, simpleRequest.getRequestHash(request));
+        bytes memory signature1 = _sign(borrowerPK, simpleLoanSimpleRequest.getRequestHash(request));
         bytes memory requestData1 = abi.encode(request);
 
         request.loanYield = 20e18;
-        bytes memory signature2 = _sign(borrowerPK, simpleRequest.getRequestHash(request));
+        bytes memory signature2 = _sign(borrowerPK, simpleLoanSimpleRequest.getRequestHash(request));
         bytes memory requestData2 = abi.encode(request);
 
         // Approve loan asset
@@ -51,7 +51,7 @@ contract PWNSimpleLoanSimpleRequestIntegrationTest is BaseIntegrationTest {
         // Create LOAN with request 2
         vm.prank(lender);
         simpleLoan.createLOAN({
-            loanTermsFactoryContract: address(simpleRequest),
+            loanTermsFactoryContract: address(simpleLoanSimpleRequest),
             loanTermsFactoryData: requestData2,
             signature: signature2,
             loanAssetPermit: "",
@@ -62,7 +62,7 @@ contract PWNSimpleLoanSimpleRequestIntegrationTest is BaseIntegrationTest {
         vm.expectRevert(abi.encodeWithSelector(NonceAlreadyRevoked.selector));
         vm.prank(lender);
         simpleLoan.createLOAN({
-            loanTermsFactoryContract: address(simpleRequest),
+            loanTermsFactoryContract: address(simpleLoanSimpleRequest),
             loanTermsFactoryData: requestData1,
             signature: signature1,
             loanAssetPermit: "",

--- a/test/integration/contracts/PWNSimpleLoanSimpleRequestIntegration.t.sol
+++ b/test/integration/contracts/PWNSimpleLoanSimpleRequestIntegration.t.sol
@@ -30,7 +30,6 @@ contract PWNSimpleLoanSimpleRequestIntegrationTest is BaseIntegrationTest {
             expiration: 0,
             borrower: borrower,
             lender: lender,
-            lateRepaymentEnabled: false,
             nonce: nonce
         });
         bytes memory signature1 = _sign(borrowerPK, simpleLoanSimpleRequest.getRequestHash(request));

--- a/test/integration/use-cases/UseCases.t.sol
+++ b/test/integration/use-cases/UseCases.t.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.16;
+
+import "forge-std/Test.sol";
+
+import "MultiToken/interfaces/ICryptoKitties.sol";
+
+import "@pwn-test/helper/token/T20.sol";
+import "@pwn-test/helper/DeploymentTest.t.sol";
+
+
+/*
+
+Run tests with this command:
+
+forge t -f mainnet --mp test/integration/use-cases/UseCases.t.sol
+
+*/
+abstract contract UseCasesTest is DeploymentTest {
+
+    // Token mainnet addresses
+    address ZRX = 0xE41d2489571d322189246DaFA5ebDe1F4699F498; // no revert on failed
+    address WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2; // no revert on fallback
+    address CULT = 0xf0f9D895aCa5c8678f706FB8216fa22957685A13; // tax token
+    address CK = 0x06012c8cf97BEaD5deAe237070F9587f8E7A266d; // CryptoKitties
+    address USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7; // no bool return on transfer(From)
+    address BNB = 0xB8c77482e45F1F44dE1745F52C74426C631bDD52; // bool return only on transfer
+
+    T20 loanAsset;
+    address lender = makeAddr("lender");
+    address borrower = makeAddr("borrower");
+
+    PWNSimpleLoanSimpleOffer.Offer offer;
+
+
+    function setUp() public override {
+        super.setUp();
+
+        loanAsset = new T20();
+        loanAsset.mint(lender, 100e18);
+        loanAsset.mint(borrower, 100e18);
+
+        vm.prank(lender);
+        loanAsset.approve(address(simpleLoan), type(uint256).max);
+
+        vm.prank(borrower);
+        loanAsset.approve(address(simpleLoan), type(uint256).max);
+
+        offer = PWNSimpleLoanSimpleOffer.Offer({
+            collateralCategory: MultiToken.Category.ERC20,
+            collateralAddress: address(loanAsset),
+            collateralId: 0,
+            collateralAmount: 10e18,
+            loanAssetAddress: address(loanAsset),
+            loanAmount: 1e18,
+            loanYield: 0,
+            duration: 3600,
+            expiration: 0,
+            borrower: address(0),
+            lender: lender,
+            isPersistent: false,
+            lateRepaymentEnabled: false,
+            nonce: 0
+        });
+    }
+
+
+    function _createLoan() internal returns (uint256) {
+        return _createLoanRevertWith("");
+    }
+
+    function _createLoanRevertWith(bytes memory revertData) internal returns (uint256) {
+        // Make offer
+        vm.prank(lender);
+        simpleLoanSimpleOffer.makeOffer(offer);
+
+        bytes memory factoryData = simpleLoanSimpleOffer.encodeLoanTermsFactoryData(offer);
+
+        // Create a loan
+        if (revertData.length > 0) {
+            vm.expectRevert(revertData);
+        }
+        vm.prank(borrower);
+        return simpleLoan.createLOAN({
+            loanTermsFactoryContract: address(simpleLoanSimpleOffer),
+            loanTermsFactoryData: factoryData,
+            signature: "",
+            loanAssetPermit: "",
+            collateralPermit: ""
+        });
+    }
+
+}
+
+
+contract InvalidCollateralAssetCategoryTest is UseCasesTest {
+
+    // “No Revert on Failure” tokens can be used to steal from lender
+    function testUseCase_shouldFail_when20CollateralPassedWith721Category() external {
+        // Borrower has not ZRX tokens
+
+        // Define offer
+        offer.collateralCategory = MultiToken.Category.ERC721;
+        offer.collateralAddress = ZRX;
+        offer.collateralId = 10e18;
+        offer.collateralAmount = 0;
+
+        // Create loan
+        _createLoanRevertWith(abi.encodeWithSelector(InvalidCollateralAsset.selector));
+    }
+
+    // Borrower can steal lender’s assets by using WETH as collateral
+    function testUseCase_shouldFail_when20CollateralPassedWith1155Category() external {
+        // Borrower has not WETH tokens
+
+        // Define offer
+        offer.collateralCategory = MultiToken.Category.ERC1155;
+        offer.collateralAddress = WETH;
+        offer.collateralId = 0;
+        offer.collateralAmount = 10e18;
+
+        // Create loan
+        _createLoanRevertWith(abi.encodeWithSelector(InvalidCollateralAsset.selector));
+    }
+
+    // CryptoKitties token is locked when using it as ERC721 type collateral
+    function testUseCase_shouldFail_whenCryptoKittiesCollateralPassedWith721Category() external {
+        uint256 ckId = 42;
+
+        // Mock CK
+        address originalCkOwner = ICryptoKitties(CK).ownerOf(ckId);
+        vm.prank(originalCkOwner);
+        ICryptoKitties(CK).transfer(borrower, ckId);
+
+        vm.prank(borrower);
+        ICryptoKitties(CK).approve(address(simpleLoan), ckId);
+
+        // Define offer
+        offer.collateralCategory = MultiToken.Category.ERC721;
+        offer.collateralAddress = CK;
+        offer.collateralId = ckId;
+        offer.collateralAmount = 0;
+
+        // Create loan
+        _createLoanRevertWith(abi.encodeWithSelector(InvalidCollateralAsset.selector));
+    }
+
+}
+
+
+contract TaxTokensTest is UseCasesTest {
+
+    // Fee-on-transfer tokens can be locked in the vault
+    function testUseCase_shouldFail_whenUsingTaxTokenAsCollateral() external {
+        // Transfer CULT to borrower
+        vm.prank(CULT);
+        T20(CULT).transfer(borrower, 20e18);
+
+        vm.prank(borrower);
+        T20(CULT).approve(address(simpleLoan), type(uint256).max);
+
+        // Define offer
+        offer.collateralCategory = MultiToken.Category.ERC20;
+        offer.collateralAddress = CULT;
+        offer.collateralId = 0;
+        offer.collateralAmount = 10e18;
+
+        // Create loan
+        _createLoanRevertWith("TODO");
+    }
+
+    // Fee-on-transfer tokens can be locked in the vault
+    function testUseCase_shouldFail_whenUsingTaxTokenAsCredit() external {
+        // Transfer CULT to lender
+        vm.prank(CULT);
+        T20(CULT).transfer(lender, 20e18);
+
+        vm.prank(lender);
+        T20(CULT).approve(address(simpleLoan), type(uint256).max);
+
+        // Define offer
+        offer.loanAssetAddress = CULT;
+        offer.loanAmount = 10e18;
+
+        // Create loan
+        _createLoanRevertWith("TODO");
+    }
+
+}
+
+
+// Some common ERC20 tokens can’t be used in the protocol
+contract IncompleteERC20TokensTest is UseCasesTest {
+
+    function testUseCase_shouldPass_when20TokenTransferNotReturnsBool_whenUsedAsCollateral() external {
+        address TetherTreasury = 0x5754284f345afc66a98fbB0a0Afe71e0F007B949;
+
+        // Transfer USDT to borrower
+        bool success;
+        vm.prank(TetherTreasury);
+        (success, ) = USDT.call(abi.encodeWithSignature("transfer(address,uint256)", borrower, 10e6));
+        require(success);
+
+        vm.prank(borrower);
+        (success, ) = USDT.call(abi.encodeWithSignature("approve(address,uint256)", address(simpleLoan), type(uint256).max));
+        require(success);
+
+        // Define offer
+        offer.collateralCategory = MultiToken.Category.ERC20;
+        offer.collateralAddress = USDT;
+        offer.collateralId = 0;
+        offer.collateralAmount = 10e6; // USDT has 6 decimals
+
+        // Check balance
+        assertEq(T20(USDT).balanceOf(borrower), 10e6);
+        assertEq(T20(USDT).balanceOf(address(simpleLoan)), 0);
+
+        // Create loan
+        uint256 loanId = _createLoan();
+
+        // Check balance
+        assertEq(T20(USDT).balanceOf(borrower), 0);
+        assertEq(T20(USDT).balanceOf(address(simpleLoan)), 10e6);
+
+        // Repay loan
+        vm.prank(borrower);
+        simpleLoan.repayLOAN({
+            loanId: loanId,
+            loanAssetPermit: ""
+        });
+
+        // Check balance
+        assertEq(T20(USDT).balanceOf(borrower), 10e6);
+        assertEq(T20(USDT).balanceOf(address(simpleLoan)), 0);
+    }
+
+    function testUseCase_shouldPass_when20TokenTransferNotReturnsBool_whenUsedAsCredit() external {
+        address TetherTreasury = 0x5754284f345afc66a98fbB0a0Afe71e0F007B949;
+
+        // Transfer USDT to lender
+        bool success;
+        vm.prank(TetherTreasury);
+        (success, ) = USDT.call(abi.encodeWithSignature("transfer(address,uint256)", lender, 10e6));
+        require(success);
+
+        vm.prank(lender);
+        (success, ) = USDT.call(abi.encodeWithSignature("approve(address,uint256)", address(simpleLoan), type(uint256).max));
+        require(success);
+
+        vm.prank(borrower);
+        (success, ) = USDT.call(abi.encodeWithSignature("approve(address,uint256)", address(simpleLoan), type(uint256).max));
+        require(success);
+
+        // Define offer
+        offer.loanAssetAddress = USDT;
+        offer.loanAmount = 10e6; // USDT has 6 decimals
+
+        // Check balance
+        assertEq(T20(USDT).balanceOf(lender), 10e6);
+        assertEq(T20(USDT).balanceOf(borrower), 0);
+
+        // Create loan
+        uint256 loanId = _createLoan();
+
+        // Check balance
+        assertEq(T20(USDT).balanceOf(lender), 0);
+        assertEq(T20(USDT).balanceOf(borrower), 10e6);
+
+        // Repay loan
+        vm.prank(borrower);
+        simpleLoan.repayLOAN({
+            loanId: loanId,
+            loanAssetPermit: ""
+        });
+
+        // Check balance
+        assertEq(T20(USDT).balanceOf(lender), 0);
+        assertEq(T20(USDT).balanceOf(address(simpleLoan)), 10e6);
+
+        // Claim repaid loan
+        vm.prank(lender);
+        simpleLoan.claimLOAN(loanId);
+
+        // Check balance
+        assertEq(T20(USDT).balanceOf(lender), 10e6);
+        assertEq(T20(USDT).balanceOf(address(simpleLoan)), 0);
+    }
+
+}

--- a/test/integration/use-cases/UseCases.t.sol
+++ b/test/integration/use-cases/UseCases.t.sol
@@ -55,7 +55,6 @@ abstract contract UseCasesTest is DeploymentTest {
             borrower: address(0),
             lender: lender,
             isPersistent: false,
-            lateRepaymentEnabled: false,
             nonce: 0
         });
     }

--- a/test/integration/use-cases/UseCases.t.sol
+++ b/test/integration/use-cases/UseCases.t.sol
@@ -205,7 +205,7 @@ contract TaxTokensTest is UseCasesTest {
         offer.collateralAmount = 10e18;
 
         // Create loan
-        _createLoanRevertWith("TODO");
+        _createLoanRevertWith(abi.encodeWithSelector(IncompleteTransfer.selector));
     }
 
     // Fee-on-transfer tokens can be locked in the vault
@@ -222,13 +222,12 @@ contract TaxTokensTest is UseCasesTest {
         offer.loanAmount = 10e18;
 
         // Create loan
-        _createLoanRevertWith("TODO");
+        _createLoanRevertWith(abi.encodeWithSelector(IncompleteTransfer.selector));
     }
 
 }
 
 
-// Some common ERC20 tokens can’t be used in the protocol
 contract IncompleteERC20TokensTest is UseCasesTest {
 
     function testUseCase_shouldPass_when20TokenTransferNotReturnsBool_whenUsedAsCollateral() external {

--- a/test/unit/PWNConfig.t.sol
+++ b/test/unit/PWNConfig.t.sol
@@ -132,6 +132,14 @@ contract PWNConfig_SetFee_Test is PWNConfigTest {
         config.setFee(9);
     }
 
+    function test_shouldFaile_whenNewValueBiggerThanMaxFee() external {
+        uint16 maxFee = config.MAX_FEE();
+
+        vm.expectRevert(abi.encodeWithSelector(InvalidFeeValue.selector));
+        vm.prank(owner);
+        config.setFee(maxFee + 1);
+    }
+
     function test_shouldSetFeeValue() external {
         uint16 fee = 9;
 

--- a/test/unit/PWNConfig.t.sol
+++ b/test/unit/PWNConfig.t.sol
@@ -8,6 +8,12 @@ import "@pwn/config/PWNConfig.sol";
 
 abstract contract PWNConfigTest is Test {
 
+    bytes32 internal constant OWNER_SLOT = bytes32(uint256(0)); // `_owner` property position
+    bytes32 internal constant PENDING_OWNER_SLOT = bytes32(uint256(1)); // `_pendingOwner` property position
+    bytes32 internal constant FEE_SLOT = bytes32(uint256(1)); // `fee` property position
+    bytes32 internal constant FEE_COLLECTOR_SLOT = bytes32(uint256(2)); // `feeCollector` property position
+    bytes32 internal constant LOAN_METADATA_URI_SLOT = bytes32(uint256(3)); // `loanMetadataUri` mapping position
+
     PWNConfig config;
     address owner = address(0x43);
     address feeCollector = address(0xfeeC001ec704);
@@ -32,7 +38,7 @@ contract PWNConfig_Initialize_Test is PWNConfigTest {
     function test_shouldSetOwner() external {
         config.initialize(owner);
 
-        bytes32 ownerValue = vm.load(address(config), bytes32(0));
+        bytes32 ownerValue = vm.load(address(config), OWNER_SLOT);
         assertEq(address(uint160(uint256(ownerValue))), owner);
     }
 
@@ -63,11 +69,13 @@ contract PWNConfig_Reinitialize_Test is PWNConfigTest {
     function test_shouldSetParameters() external {
         config.reinitialize(owner, fee, feeCollector);
 
-        bytes32 firstSlotValue = vm.load(address(config), bytes32(0));
-        assertEq(address(uint160(uint256(firstSlotValue))), owner);
-        assertEq(uint16(uint256(firstSlotValue >> 176)), fee);
+        bytes32 ownerValue = vm.load(address(config), OWNER_SLOT);
+        assertEq(address(uint160(uint256(ownerValue))), owner);
 
-        bytes32 feeCollectorValue = vm.load(address(config), bytes32(uint256(1)));
+        bytes32 feeSlotValue = vm.load(address(config), FEE_SLOT);
+        assertEq(uint16(uint256(feeSlotValue >> 176)), fee);
+
+        bytes32 feeCollectorValue = vm.load(address(config), FEE_COLLECTOR_SLOT);
         assertEq(address(uint160(uint256(feeCollectorValue))), feeCollector);
     }
 
@@ -130,8 +138,8 @@ contract PWNConfig_SetFee_Test is PWNConfigTest {
         vm.prank(owner);
         config.setFee(fee);
 
-        bytes32 firstSlotValue = vm.load(address(config), bytes32(0));
-        assertEq(uint16(uint256(firstSlotValue >> 176)), fee);
+        bytes32 feeSlotValue = vm.load(address(config), FEE_SLOT);
+        assertEq(uint16(uint256(feeSlotValue >> 176)), fee);
     }
 
     function test_shouldEmitEvent_FeeUpdated() external {
@@ -170,7 +178,7 @@ contract PWNConfig_SetFeeCollector_Test is PWNConfigTest {
         vm.prank(owner);
         config.setFeeCollector(newFeeCollector);
 
-        bytes32 feeCollectorValue = vm.load(address(config), bytes32(uint256(1)));
+        bytes32 feeCollectorValue = vm.load(address(config), FEE_COLLECTOR_SLOT);
         assertEq(uint160(uint256(feeCollectorValue)), uint160(newFeeCollector));
     }
 
@@ -212,7 +220,7 @@ contract PWNConfig_SetLoanMetadataUri_Test is PWNConfigTest {
 
         bytes32 tokenUriValue = vm.load(
             address(config),
-            keccak256(abi.encode(loanContract, uint256(2)))
+            keccak256(abi.encode(loanContract, LOAN_METADATA_URI_SLOT))
         );
         bytes memory memoryTokenUri = bytes(tokenUri);
         bytes32 _tokenUri;

--- a/test/unit/PWNConfig.t.sol
+++ b/test/unit/PWNConfig.t.sol
@@ -182,6 +182,12 @@ contract PWNConfig_SetFeeCollector_Test is PWNConfigTest {
         config.setFeeCollector(newFeeCollector);
     }
 
+    function test_shouldFail_whenSettingZeroAddress() external {
+        vm.expectRevert(abi.encodeWithSelector(InvalidFeeCollector.selector));
+        vm.prank(owner);
+        config.setFeeCollector(address(0));
+    }
+
     function test_shouldSetFeeCollectorAddress() external {
         vm.prank(owner);
         config.setFeeCollector(newFeeCollector);

--- a/test/unit/PWNHub.t.sol
+++ b/test/unit/PWNHub.t.sol
@@ -9,7 +9,7 @@ import "@pwn/PWNErrors.sol";
 
 abstract contract PWNHubTest is Test {
 
-    bytes32 internal constant TAGS_SLOT = bytes32(uint256(1)); // `tags` mapping position
+    bytes32 internal constant TAGS_SLOT = bytes32(uint256(2)); // `tags` mapping position
 
     PWNHub hub;
     address owner = address(0x1001);
@@ -19,8 +19,8 @@ abstract contract PWNHubTest is Test {
     event TagSet(address indexed _address, bytes32 indexed tag, bool hasTag);
 
     function setUp() external {
+        vm.prank(owner);
         hub = new PWNHub();
-        hub.transferOwnership(owner);
     }
 
 

--- a/test/unit/PWNSimpleLoan.t.sol
+++ b/test/unit/PWNSimpleLoan.t.sol
@@ -786,19 +786,15 @@ contract PWNSimpleLoan_GetStateFingerprint_Test is PWNSimpleLoanTest {
     function test_shouldReturnCorrectStateFingerprint() external {
         _mockLOAN(loanId, simpleLoan);
         vm.warp(30039);
-        assertEq(loan.getStateFingerprint(loanId), keccak256(abi.encode(2, 40039, false)));
+        assertEq(loan.getStateFingerprint(loanId), keccak256(abi.encode(2, 40039)));
 
         vm.warp(50039);
-        assertEq(loan.getStateFingerprint(loanId), keccak256(abi.encode(2, 40039, true)));
+        assertEq(loan.getStateFingerprint(loanId), keccak256(abi.encode(4, 40039)));
 
-        simpleLoan.status = 5;
-        _mockLOAN(loanId, simpleLoan);
-        assertEq(loan.getStateFingerprint(loanId), keccak256(abi.encode(5, 40039, false)));
-
-        simpleLoan.status = 2;
+        simpleLoan.status = 3;
         simpleLoan.expiration = 60039;
         _mockLOAN(loanId, simpleLoan);
-        assertEq(loan.getStateFingerprint(loanId), keccak256(abi.encode(2, 60039, false)));
+        assertEq(loan.getStateFingerprint(loanId), keccak256(abi.encode(3, 60039)));
     }
 
 }

--- a/test/unit/PWNSimpleLoan.t.sol
+++ b/test/unit/PWNSimpleLoan.t.sol
@@ -717,6 +717,14 @@ contract PWNSimpleLoan_GetLOAN_Test is PWNSimpleLoanTest {
         _assertLOANEq(loan.getLOAN(loanId), simpleLoan);
     }
 
+    function test_shouldReturnExpiredStatus_whenLOANExpired() external {
+        vm.warp(50039);
+        _mockLOAN(loanId, simpleLoan);
+
+        simpleLoan.status = 4;
+        _assertLOANEq(loan.getLOAN(loanId), simpleLoan);
+    }
+
     function test_shouldReturnEmptyLOANDataForNonExistingLoan() external {
         _assertLOANEq(loan.getLOAN(loanId), nonExistingLoan);
     }

--- a/test/unit/PWNSimpleLoanListOffer.t.sol
+++ b/test/unit/PWNSimpleLoanListOffer.t.sol
@@ -266,8 +266,10 @@ contract PWNSimpleLoanListOffer_CreateLOANTerms_Test is PWNSimpleLoanListOfferTe
         offerContract.createLOANTerms(borrower, abi.encode(offer, offerValues), signature);
     }
 
-    function test_shouldFail_whenZeroDuration() external {
-        offer.duration = 0;
+    function testFuzz_shouldFail_whenLessThanMinDuration(uint32 duration) external {
+        vm.assume(duration < offerContract.MIN_LOAN_DURATION());
+
+        offer.duration = duration;
         signature = _signOfferCompact(lenderPK, offer);
 
         vm.expectRevert(abi.encodeWithSelector(InvalidDuration.selector));

--- a/test/unit/PWNSimpleLoanListOffer.t.sol
+++ b/test/unit/PWNSimpleLoanListOffer.t.sol
@@ -47,7 +47,6 @@ abstract contract PWNSimpleLoanListOfferTest is Test {
             borrower: address(0),
             lender: lender,
             isPersistent: false,
-            lateRepaymentEnabled: false,
             nonce: uint256(keccak256("nonce_1"))
         });
 
@@ -75,7 +74,7 @@ abstract contract PWNSimpleLoanListOfferTest is Test {
                 address(offerContract)
             )),
             keccak256(abi.encodePacked(
-                keccak256("Offer(uint8 collateralCategory,address collateralAddress,bytes32 collateralIdsWhitelistMerkleRoot,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bool lateRepaymentEnabled,uint256 nonce)"),
+                keccak256("Offer(uint8 collateralCategory,address collateralAddress,bytes32 collateralIdsWhitelistMerkleRoot,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,uint256 nonce)"),
                 abi.encode(_offer)
             ))
         ));
@@ -353,7 +352,6 @@ contract PWNSimpleLoanListOffer_CreateLOANTerms_Test is PWNSimpleLoanListOfferTe
         assertTrue(loanTerms.lender == offer.lender);
         assertTrue(loanTerms.borrower == borrower);
         assertTrue(loanTerms.expiration == currentTimestamp + offer.duration);
-        assertTrue(loanTerms.lateRepaymentEnabled == offer.lateRepaymentEnabled);
         assertTrue(loanTerms.collateral.category == offer.collateralCategory);
         assertTrue(loanTerms.collateral.assetAddress == offer.collateralAddress);
         assertTrue(loanTerms.collateral.id == offerValues.collateralId);

--- a/test/unit/PWNSimpleLoanListOffer.t.sol
+++ b/test/unit/PWNSimpleLoanListOffer.t.sol
@@ -266,6 +266,15 @@ contract PWNSimpleLoanListOffer_CreateLOANTerms_Test is PWNSimpleLoanListOfferTe
         offerContract.createLOANTerms(borrower, abi.encode(offer, offerValues), signature);
     }
 
+    function test_shouldFail_whenZeroDuration() external {
+        offer.duration = 0;
+        signature = _signOfferCompact(lenderPK, offer);
+
+        vm.expectRevert(abi.encodeWithSelector(InvalidDuration.selector));
+        vm.prank(activeLoanContract);
+        offerContract.createLOANTerms(borrower, abi.encode(offer, offerValues), signature);
+    }
+
     function test_shouldRevokeOffer_whenIsNotPersistent() external {
         offer.isPersistent = false;
         signature = _signOfferCompact(lenderPK, offer);

--- a/test/unit/PWNSimpleLoanSimpleOffer.t.sol
+++ b/test/unit/PWNSimpleLoanSimpleOffer.t.sol
@@ -260,6 +260,15 @@ contract PWNSimpleLoanSimpleOffer_CreateLOANTerms_Test is PWNSimpleLoanSimpleOff
         offerContract.createLOANTerms(borrower, abi.encode(offer), signature);
     }
 
+    function test_shouldFail_whenZeroDuration() external {
+        offer.duration = 0;
+        signature = _signOfferCompact(lenderPK, offer);
+
+        vm.expectRevert(abi.encodeWithSelector(InvalidDuration.selector));
+        vm.prank(activeLoanContract);
+        offerContract.createLOANTerms(borrower, abi.encode(offer), signature);
+    }
+
     function test_shouldRevokeOffer_whenIsNotPersistent() external {
         offer.isPersistent = false;
         signature = _signOfferCompact(lenderPK, offer);

--- a/test/unit/PWNSimpleLoanSimpleOffer.t.sol
+++ b/test/unit/PWNSimpleLoanSimpleOffer.t.sol
@@ -260,8 +260,10 @@ contract PWNSimpleLoanSimpleOffer_CreateLOANTerms_Test is PWNSimpleLoanSimpleOff
         offerContract.createLOANTerms(borrower, abi.encode(offer), signature);
     }
 
-    function test_shouldFail_whenZeroDuration() external {
-        offer.duration = 0;
+    function testFuzz_shouldFail_whenLessThanMinDuration(uint32 duration) external {
+        vm.assume(duration < offerContract.MIN_LOAN_DURATION());
+
+        offer.duration = duration;
         signature = _signOfferCompact(lenderPK, offer);
 
         vm.expectRevert(abi.encodeWithSelector(InvalidDuration.selector));

--- a/test/unit/PWNSimpleLoanSimpleOffer.t.sol
+++ b/test/unit/PWNSimpleLoanSimpleOffer.t.sol
@@ -46,7 +46,6 @@ abstract contract PWNSimpleLoanSimpleOfferTest is Test {
             borrower: address(0),
             lender: lender,
             isPersistent: false,
-            lateRepaymentEnabled: false,
             nonce: uint256(keccak256("nonce_1"))
         });
 
@@ -69,7 +68,7 @@ abstract contract PWNSimpleLoanSimpleOfferTest is Test {
                 address(offerContract)
             )),
             keccak256(abi.encodePacked(
-                keccak256("Offer(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,bool lateRepaymentEnabled,uint256 nonce)"),
+                keccak256("Offer(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool isPersistent,uint256 nonce)"),
                 abi.encode(_offer)
             ))
         ));
@@ -309,7 +308,6 @@ contract PWNSimpleLoanSimpleOffer_CreateLOANTerms_Test is PWNSimpleLoanSimpleOff
         assertTrue(loanTerms.lender == offer.lender);
         assertTrue(loanTerms.borrower == borrower);
         assertTrue(loanTerms.expiration == currentTimestamp + offer.duration);
-        assertTrue(loanTerms.lateRepaymentEnabled == offer.lateRepaymentEnabled);
         assertTrue(loanTerms.collateral.category == offer.collateralCategory);
         assertTrue(loanTerms.collateral.assetAddress == offer.collateralAddress);
         assertTrue(loanTerms.collateral.id == offer.collateralId);

--- a/test/unit/PWNSimpleLoanSimpleRequest.t.sol
+++ b/test/unit/PWNSimpleLoanSimpleRequest.t.sol
@@ -259,8 +259,10 @@ contract PWNSimpleLoanSimpleRequest_CreateLOANTerms_Test is PWNSimpleLoanSimpleR
         requestContract.createLOANTerms(lender, abi.encode(request), signature);
     }
 
-    function test_shouldFail_whenZeroDuration() external {
-        request.duration = 0;
+    function testFuzz_shouldFail_whenLessThanMinDuration(uint32 duration) external {
+        vm.assume(duration < requestContract.MIN_LOAN_DURATION());
+
+        request.duration = duration;
         signature = _signRequestCompact(borrowerPK, request);
 
         vm.expectRevert(abi.encodeWithSelector(InvalidDuration.selector));

--- a/test/unit/PWNSimpleLoanSimpleRequest.t.sol
+++ b/test/unit/PWNSimpleLoanSimpleRequest.t.sol
@@ -45,7 +45,6 @@ abstract contract PWNSimpleLoanSimpleRequestTest is Test {
             expiration: 0,
             borrower: borrower,
             lender: address(0),
-            lateRepaymentEnabled: false,
             nonce: uint256(keccak256("nonce_1"))
         });
 
@@ -68,7 +67,7 @@ abstract contract PWNSimpleLoanSimpleRequestTest is Test {
                 address(requestContract)
             )),
             keccak256(abi.encodePacked(
-                keccak256("Request(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,bool lateRepaymentEnabled,uint256 nonce)"),
+                keccak256("Request(uint8 collateralCategory,address collateralAddress,uint256 collateralId,uint256 collateralAmount,address loanAssetAddress,uint256 loanAmount,uint256 loanYield,uint32 duration,uint40 expiration,address borrower,address lender,uint256 nonce)"),
                 abi.encode(_request)
             ))
         ));
@@ -293,7 +292,6 @@ contract PWNSimpleLoanSimpleRequest_CreateLOANTerms_Test is PWNSimpleLoanSimpleR
         assertTrue(loanTerms.lender == lender);
         assertTrue(loanTerms.borrower == request.borrower);
         assertTrue(loanTerms.expiration == currentTimestamp + request.duration);
-        assertTrue(loanTerms.lateRepaymentEnabled == request.lateRepaymentEnabled);
         assertTrue(loanTerms.collateral.category == request.collateralCategory);
         assertTrue(loanTerms.collateral.assetAddress == request.collateralAddress);
         assertTrue(loanTerms.collateral.id == request.collateralId);

--- a/test/unit/PWNSimpleLoanSimpleRequest.t.sol
+++ b/test/unit/PWNSimpleLoanSimpleRequest.t.sol
@@ -259,6 +259,15 @@ contract PWNSimpleLoanSimpleRequest_CreateLOANTerms_Test is PWNSimpleLoanSimpleR
         requestContract.createLOANTerms(lender, abi.encode(request), signature);
     }
 
+    function test_shouldFail_whenZeroDuration() external {
+        request.duration = 0;
+        signature = _signRequestCompact(borrowerPK, request);
+
+        vm.expectRevert(abi.encodeWithSelector(InvalidDuration.selector));
+        vm.prank(activeLoanContract);
+        requestContract.createLOANTerms(lender, abi.encode(request), signature);
+    }
+
     function test_shouldRevokeRequest() external {
         signature = _signRequestCompact(borrowerPK, request);
 


### PR DESCRIPTION
- make `PWNConfig` & `PWNHub` inherit `Ownable2Step` instead of `Ownable`
- set max fee size to 10%
- set min loan duration to 10 min
- transfer fee to fee collector only if amount is >0
- fix fee amount lib
- update `MultiToken` library, which fixed issues with malicious asset category
- check loan asset validity before creating a loan
- check valid transfer by checking balances after the transfer
- remove `enableLOANLateRepayment` function
- implement `extendLOANExpirationDate` function
- fix expired loan status in `getLOAN` return
- use status value for expired loans instead of using expired flag in the state fingerprint